### PR TITLE
ISpread.GetRange index bugfix

### DIFF
--- a/vvvv45/src/core/PluginInterfaces/V2/ISpread.cs
+++ b/vvvv45/src/core/PluginInterfaces/V2/ISpread.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -306,9 +306,9 @@ namespace VVVV.PluginInterfaces.V2
         {
             var result = new Spread<T>(count);
             
-            for (int i = index; i < index + count; i++)
+            for (int i = 0; i < count; i++)
             {
-                result[i] = spread[i];
+                result[i] = spread[index+i];
             }
             
             return result;


### PR DESCRIPTION
returned spread was shifting slices when index!=0
