### PR TITLE
Added a new module 'FourRooms (Transform Viewport)'

### DIFF
--- a/vvvv45/addonpack/lib/nodes/modules/Transform/FourRooms (Transform Viewport) help.v4p
+++ b/vvvv45/addonpack/lib/nodes/modules/Transform/FourRooms (Transform Viewport) help.v4p
@@ -1,0 +1,235 @@
+<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45beta26.dtd" >
+   <PATCH nodename="C:\kimchiandchips\VVVV.Research\vvvv-sdk\vvvv45\addonpack\lib\nodes\modules\Transform\FourRooms (Transform Viewport) help.v4p" systemname="FourRooms (Transform Viewport) help" filename="C:\kimchiandchips\VVVV.Research\vvvv-sdk\vvvv45\addonpack\lib\nodes\modules\Transform\FourRooms (Transform Viewport) help.v4p">
+   <BOUNDS type="Window" left="9060" top="870" width="13665" height="12705">
+   </BOUNDS>
+   <NODE componentmode="InABox" id="0" nodename="Renderer (EX9)" systemname="Renderer (EX9)">
+   <BOUNDS height="100" left="645" top="5010" type="Node" width="100">
+   </BOUNDS>
+   <BOUNDS height="7080" left="645" top="5010" type="Box" width="9945">
+   </BOUNDS>
+   <BOUNDS height="5010" left="13695" top="11280" type="Window" width="6240">
+   </BOUNDS>
+   <PIN pinname="Layers" visible="1">
+   </PIN>
+   <PIN pinname="Viewport" pintype="Input" visible="1">
+   </PIN>
+   <PIN pinname="View" visible="1">
+   </PIN>
+   <PIN pinname="Projection" visible="1">
+   </PIN>
+   <PIN pinname="Background Color" visible="1" slicecount="1" values="|0.00000,0.00000,0.00000,1.00000|">
+   </PIN>
+   <PIN pinname="Windowed Antialiasing Quality Level" slicecount="1" values="3">
+   </PIN>
+   <PIN pinname="Windowed Depthbuffer Format" slicecount="1" values="D16">
+   </PIN>
+   </NODE>
+   <NODE systemname="FourRooms (Transform Viewport)" filename="FourRooms (Transform Viewport).v4p" nodename="FourRooms (Transform Viewport)" componentmode="InAWindow" id="2">
+   <BOUNDS type="Node" left="660" top="4500" width="9945" height="270">
+   </BOUNDS>
+   <PIN pinname="Layer" visible="1">
+   </PIN>
+   <PIN pinname="Viewports" visible="1">
+   </PIN>
+   <PIN pinname="Projection" visible="1">
+   </PIN>
+   <PIN pinname="View" visible="1">
+   </PIN>
+   <BOUNDS type="Window" left="16110" top="7425" width="9780" height="5400">
+   </BOUNDS>
+   </NODE>
+   <LINK srcnodeid="2" srcpinname="Layer" dstnodeid="0" dstpinname="Layers">
+   </LINK>
+   <LINK srcnodeid="2" srcpinname="Viewports" dstnodeid="0" dstpinname="Viewport">
+   </LINK>
+   <LINK srcnodeid="2" srcpinname="Projection" dstnodeid="0" dstpinname="Projection" linkstyle="VHV">
+   <LINKPOINT x="7305" y="4875">
+   </LINKPOINT>
+   <LINKPOINT x="8550" y="4875">
+   </LINKPOINT>
+   </LINK>
+   <LINK srcnodeid="2" srcpinname="View" dstnodeid="0" dstpinname="View" linkstyle="VHV">
+   <LINKPOINT x="4020" y="4875">
+   </LINKPOINT>
+   <LINKPOINT x="7560" y="4875">
+   </LINKPOINT>
+   </LINK>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="3" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="10740" top="4590" width="2235" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="10740" top="4590" width="2415" height="1395">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="|//you must manually connect&cr;&lf;Layer,View,Projection,Viewport&cr;&lf;between the FourRooms module and the renderer (note that Viewport pin is hidden by default on the Renderer)|" encoded="0">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   </NODE>
+   <NODE systemname="Sphere (DX9)" nodename="Sphere (DX9)" componentmode="Hidden" id="6">
+   <BOUNDS type="Node" left="660" top="3375" width="8115" height="270">
+   </BOUNDS>
+   <PIN pinname="Layer" visible="1">
+   </PIN>
+   <PIN pinname="Transform" visible="1">
+   </PIN>
+   <PIN pinname="Color" visible="1">
+   </PIN>
+   <PIN pinname="Resolution X" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Resolution Y" slicecount="1" values="4">
+   </PIN>
+   </NODE>
+   <NODE systemname="RandomSpread (Spreads)" nodename="RandomSpread (Spreads)" componentmode="Hidden" id="8">
+   <BOUNDS type="Node" left="2160" top="1935" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <PIN pinname="Spread Count" slicecount="1" values="30">
+   </PIN>
+   <PIN pinname="Random Seed" visible="1">
+   </PIN>
+   <PIN pinname="Width" slicecount="1" values="10">
+   </PIN>
+   </NODE>
+   <NODE systemname="Translate (Transform Vector)" nodename="Translate (Transform Vector)" componentmode="Hidden" id="9">
+   <BOUNDS type="Node" left="1410" top="2865" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Transform Out" visible="1">
+   </PIN>
+   <PIN pinname="XYZ" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="9" srcpinname="Transform Out" dstnodeid="6" dstpinname="Transform">
+   </LINK>
+   <NODE systemname="DeNiro (Animation)" nodename="DeNiro (Animation)" componentmode="Hidden" id="10">
+   <BOUNDS type="Node" left="2160" top="2430" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Position Out" visible="1">
+   </PIN>
+   <PIN pinname="Go To Position" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="10" srcpinname="Position Out" dstnodeid="9" dstpinname="XYZ">
+   </LINK>
+   <LINK srcnodeid="8" srcpinname="Output" dstnodeid="10" dstpinname="Go To Position">
+   </LINK>
+   <NODE systemname="LFO (Animation)" nodename="LFO (Animation)" componentmode="Hidden" id="11">
+   <BOUNDS type="Node" left="2220" top="1365" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Cycles" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="11" srcpinname="Cycles" dstnodeid="8" dstpinname="Random Seed">
+   </LINK>
+   <NODE systemname="RandomSpread (Spreads)" nodename="RandomSpread (Spreads)" componentmode="Hidden" id="12">
+   <BOUNDS type="Node" left="5070" top="2325" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <PIN pinname="Spread Count" slicecount="1" values="10">
+   </PIN>
+   <PIN pinname="Width" slicecount="1" values="0.2">
+   </PIN>
+   </NODE>
+   <NODE systemname="HSL (Color Join)" nodename="HSL (Color Join)" componentmode="Hidden" id="13">
+   <BOUNDS type="Node" left="5070" top="2865" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Hue" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <PIN pinname="Lightness" slicecount="1" values="0.33">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="12" srcpinname="Output" dstnodeid="13" dstpinname="Hue">
+   </LINK>
+   <LINK srcnodeid="13" srcpinname="Output" dstnodeid="6" dstpinname="Color">
+   </LINK>
+   <NODE componentmode="InABox" id="16" nodename="IOBox (String)" systemname="IOBox (String)">
+   <BOUNDS height="255" left="645" top="495" type="Node" width="570">
+   </BOUNDS>
+   <BOUNDS height="660" left="645" top="495" type="Box" width="4365">
+   </BOUNDS>
+   <BOUNDS height="160" left="6660" top="12870" type="Window" width="215">
+   </BOUNDS>
+   <PIN encoded="0" pinname="Input String" slicecount="1" visible="0" values="|Alternative FourRooms method, using viewports instead of seperate renderers. Useful for when you only want to manage one renderer (e.g. fullscreen, etc)|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   </NODE>
+   <NODE componentmode="InABox" id="15" nodename="IOBox (String)" systemname="IOBox (String)">
+   <BOUNDS height="270" left="645" top="135" type="Node" width="915">
+   </BOUNDS>
+   <BOUNDS height="360" left="645" top="135" type="Box" width="4335">
+   </BOUNDS>
+   <BOUNDS height="160" left="6660" top="12870" type="Window" width="215">
+   </BOUNDS>
+   <PIN encoded="0" pinname="Input String" slicecount="1" visible="0" values="|FourRooms - Transform, Viewport|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Size" slicecount="1" values="12">
+   </PIN>
+   </NODE>
+   <INFO author="" description="" tags="">
+   </INFO>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="17" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="9015" top="2505" width="4260" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="9015" top="2505" width="4335" height="615">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="|//N.B. not all VVVV features are compatible with viewports&cr;&lf;notably Line (EX9.Geometry) has problems with viewports|" encoded="0">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   </NODE>
+   <NODE systemname="Line (EX9.Geometry)" nodename="Line (EX9.Geometry)" componentmode="Hidden" id="18" hiddenwhenlocked="1">
+   <BOUNDS type="Node" left="9000" top="3345" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Layer" visible="1">
+   </PIN>
+   <PIN pinname="VerticesXYZ" visible="1">
+   </PIN>
+   <PIN pinname="Color" slicecount="1" values="|0.50695,0.50695,0.50695,1.00000|">
+   </PIN>
+   <PIN pinname="Width" slicecount="1" values="2">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="10" srcpinname="Position Out" dstnodeid="18" dstpinname="VerticesXYZ" linkstyle="Bezier" hiddenwhenlocked="1">
+   <LINKPOINT x="2220" y="3008">
+   </LINKPOINT>
+   <LINKPOINT x="9165" y="3008">
+   </LINKPOINT>
+   </LINK>
+   <NODE systemname="Group (EX9)" nodename="Group (EX9)" componentmode="Hidden" id="20">
+   <BOUNDS type="Node" left="660" top="4110" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Layer 1" visible="1">
+   </PIN>
+   <PIN pinname="Layer" visible="1">
+   </PIN>
+   <PIN pinname="Layer 2" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="6" srcpinname="Layer" dstnodeid="20" dstpinname="Layer 1">
+   </LINK>
+   <LINK srcnodeid="20" srcpinname="Layer" dstnodeid="2" dstpinname="Layer">
+   </LINK>
+   <LINK srcnodeid="18" srcpinname="Layer" dstnodeid="20" dstpinname="Layer 2" linkstyle="VHV" hiddenwhenlocked="1">
+   <LINKPOINT x="9000" y="3848">
+   </LINKPOINT>
+   <LINKPOINT x="990" y="3848">
+   </LINKPOINT>
+   </LINK>
+   </PATCH>

--- a/vvvv45/addonpack/lib/nodes/modules/Transform/FourRooms (Transform Viewport).v4p
+++ b/vvvv45/addonpack/lib/nodes/modules/Transform/FourRooms (Transform Viewport).v4p
@@ -9,7 +9,7 @@
    </BOUNDS>
    <PIN pinname="Output Node" visible="1">
    </PIN>
-   <PIN pinname="Descriptive Name" slicecount="1" values="Layer" encoded="0">
+   <PIN encoded="0" pinname="Descriptive Name" slicecount="1" values="Layer">
    </PIN>
    </NODE>
    <NODE componentmode="Hidden" id="1" nodename="Group (EX9)" systemname="Group (EX9)">
@@ -29,25 +29,25 @@
    </BOUNDS>
    <PIN pinname="Layer" visible="1">
    </PIN>
-   <BOUNDS type="Box" left="300" top="2595">
+   <BOUNDS left="300" top="2595" type="Box">
    </BOUNDS>
    </NODE>
    <LINK dstnodeid="1" dstpinname="Layer 1" srcnodeid="2" srcpinname="Layer">
    </LINK>
-   <NODE systemname="IOBox (Node)" nodename="IOBox (Node)" componentmode="InABox" id="3">
-   <BOUNDS type="Node" left="300" top="4065" width="100" height="100">
+   <NODE componentmode="InABox" id="3" nodename="IOBox (Node)" systemname="IOBox (Node)">
+   <BOUNDS height="100" left="300" top="4065" type="Node" width="100">
    </BOUNDS>
-   <BOUNDS type="Box" left="300" top="4065" width="795" height="240">
+   <BOUNDS height="240" left="300" top="4065" type="Box" width="795">
    </BOUNDS>
    <PIN pinname="Input Node" visible="1">
    </PIN>
-   <PIN pinname="Descriptive Name" slicecount="1" values="Layer" encoded="0">
+   <PIN encoded="0" pinname="Descriptive Name" slicecount="1" values="Layer">
    </PIN>
    </NODE>
-   <LINK srcnodeid="1" srcpinname="Layer" dstnodeid="3" dstpinname="Input Node">
+   <LINK dstnodeid="3" dstpinname="Input Node" srcnodeid="1" srcpinname="Layer">
    </LINK>
-   <NODE systemname="Rotate (Transform Vector)" nodename="Rotate (Transform Vector)" componentmode="Hidden" id="5">
-   <BOUNDS type="Node" left="3015" top="2055" width="100" height="100">
+   <NODE componentmode="Hidden" id="5" nodename="Rotate (Transform Vector)" systemname="Rotate (Transform Vector)">
+   <BOUNDS height="100" left="3015" top="2055" type="Node" width="100">
    </BOUNDS>
    <PIN pinname="XYZ" visible="1">
    </PIN>
@@ -56,8 +56,8 @@
    <PIN pinname="Transform In" visible="1">
    </PIN>
    </NODE>
-   <NODE systemname="PeakSpread (Spreads)" nodename="PeakSpread (Spreads)" componentmode="Hidden" id="6">
-   <BOUNDS type="Node" left="3600" top="1185" width="100" height="100">
+   <NODE componentmode="Hidden" id="6" nodename="PeakSpread (Spreads)" systemname="PeakSpread (Spreads)">
+   <BOUNDS height="100" left="3600" top="1185" type="Node" width="100">
    </BOUNDS>
    <PIN pinname="Output" visible="1">
    </PIN>
@@ -66,46 +66,46 @@
    <PIN pinname="Input" visible="1">
    </PIN>
    </NODE>
-   <NODE systemname="I (Spreads)" nodename="I (Spreads)" componentmode="Hidden" id="7">
-   <BOUNDS type="Node" left="3615" top="720" width="100" height="100">
+   <NODE componentmode="Hidden" id="7" nodename="I (Spreads)" systemname="I (Spreads)">
+   <BOUNDS height="100" left="3615" top="720" type="Node" width="100">
    </BOUNDS>
    <PIN pinname="Output" visible="1">
    </PIN>
    <PIN pinname=".. To [" slicecount="1" values="3">
    </PIN>
    </NODE>
-   <LINK srcnodeid="7" srcpinname="Output" dstnodeid="6" dstpinname="Input">
+   <LINK dstnodeid="6" dstpinname="Input" srcnodeid="7" srcpinname="Output">
    </LINK>
-   <NODE systemname="MultiViewport (EX9)" filename="%VVVV%\modules\vvvv group\EX9\MultiViewport (EX9).v4p" nodename="MultiViewport (EX9)" componentmode="Hidden" id="8">
-   <BOUNDS type="Node" left="7515" top="3405" width="100" height="100">
+   <NODE componentmode="Hidden" filename="%VVVV%\modules\vvvv group\EX9\MultiViewport (EX9).v4p" id="8" nodename="MultiViewport (EX9)" systemname="MultiViewport (EX9)">
+   <BOUNDS height="100" left="7515" top="3405" type="Node" width="100">
    </BOUNDS>
    <PIN pinname="Screen Count Y" slicecount="1" values="2">
    </PIN>
-   <BOUNDS type="Box" left="7515" top="3405">
+   <BOUNDS left="7515" top="3405" type="Box">
    </BOUNDS>
    </NODE>
-   <NODE nodename="IOBox (Node)" componentmode="InABox" id="9" systemname="IOBox (Node)">
-   <BOUNDS type="Node" left="7515" top="4065" width="0" height="0">
+   <NODE componentmode="InABox" id="9" nodename="IOBox (Node)" systemname="IOBox (Node)">
+   <BOUNDS height="0" left="7515" top="4065" type="Node" width="0">
    </BOUNDS>
-   <BOUNDS type="Box" left="7515" top="4065" width="795" height="240">
+   <BOUNDS height="240" left="7515" top="4065" type="Box" width="795">
    </BOUNDS>
-   <PIN pinname="Descriptive Name" slicecount="1" values="Viewports" encoded="0">
+   <PIN encoded="0" pinname="Descriptive Name" slicecount="1" values="Viewports">
    </PIN>
    </NODE>
-   <LINK srcnodeid="8" srcpinname="Viewports" dstnodeid="9" dstpinname="Input Node">
+   <LINK dstnodeid="9" dstpinname="Input Node" srcnodeid="8" srcpinname="Viewports">
    </LINK>
-   <NODE nodename="IOBox (Node)" componentmode="InABox" id="10" systemname="IOBox (Node)">
-   <BOUNDS type="Node" left="3015" top="4065" width="0" height="0">
+   <NODE componentmode="InABox" id="10" nodename="IOBox (Node)" systemname="IOBox (Node)">
+   <BOUNDS height="0" left="3015" top="4065" type="Node" width="0">
    </BOUNDS>
-   <BOUNDS type="Box" left="3015" top="4065" width="795" height="240">
+   <BOUNDS height="240" left="3015" top="4065" type="Box" width="795">
    </BOUNDS>
-   <PIN pinname="Descriptive Name" slicecount="1" values="View" encoded="0">
+   <PIN encoded="0" pinname="Descriptive Name" slicecount="1" values="View">
    </PIN>
    <PIN pinname="Input Node" visible="1">
    </PIN>
    </NODE>
-   <NODE systemname="Divide (Value)" nodename="Divide (Value)" componentmode="Hidden" id="11">
-   <BOUNDS type="Node" left="3600" top="1650" width="100" height="100">
+   <NODE componentmode="Hidden" id="11" nodename="Divide (Value)" systemname="Divide (Value)">
+   <BOUNDS height="100" left="3600" top="1650" type="Node" width="100">
    </BOUNDS>
    <PIN pinname="Input" visible="1">
    </PIN>
@@ -114,24 +114,24 @@
    <PIN pinname="Input 2" slicecount="1" values="4">
    </PIN>
    </NODE>
-   <LINK srcnodeid="6" srcpinname="Output" dstnodeid="11" dstpinname="Input">
+   <LINK dstnodeid="11" dstpinname="Input" srcnodeid="6" srcpinname="Output">
    </LINK>
-   <LINK srcnodeid="11" srcpinname="Output" dstnodeid="5" dstpinname="XYZ">
+   <LINK dstnodeid="5" dstpinname="XYZ" srcnodeid="11" srcpinname="Output">
    </LINK>
-   <NODE systemname="IOBox (Value Advanced)" nodename="IOBox (Value Advanced)" componentmode="InABox" id="13">
-   <BOUNDS type="Node" left="5205" top="270" width="100" height="100">
+   <NODE componentmode="InABox" id="13" nodename="IOBox (Value Advanced)" systemname="IOBox (Value Advanced)">
+   <BOUNDS height="100" left="5205" top="270" type="Node" width="100">
    </BOUNDS>
-   <BOUNDS type="Box" left="5205" top="270" width="795" height="240">
+   <BOUNDS height="240" left="5205" top="270" type="Box" width="795">
    </BOUNDS>
-   <PIN pinname="Y Input Value" slicecount="1" values="5">
+   <PIN pinname="Y Input Value" slicecount="1" values="2">
    </PIN>
-   <PIN pinname="Descriptive Name" slicecount="1" values="Scale" encoded="0">
+   <PIN encoded="0" pinname="Descriptive Name" slicecount="1" values="Scale">
    </PIN>
    <PIN pinname="Y Output Value" visible="1">
    </PIN>
    </NODE>
-   <NODE systemname="Divide (Value)" nodename="Divide (Value)" componentmode="Hidden" id="14">
-   <BOUNDS type="Node" left="4950" top="1575" width="100" height="100">
+   <NODE componentmode="Hidden" id="14" nodename="Divide (Value)" systemname="Divide (Value)">
+   <BOUNDS height="100" left="4950" top="1575" type="Node" width="100">
    </BOUNDS>
    <PIN pinname="Input 2" visible="1">
    </PIN>
@@ -140,98 +140,96 @@
    <PIN pinname="Input" slicecount="1" values="2">
    </PIN>
    </NODE>
-   <LINK srcnodeid="13" srcpinname="Y Output Value" dstnodeid="14" dstpinname="Input 2">
+   <LINK dstnodeid="14" dstpinname="Input 2" srcnodeid="13" srcpinname="Y Output Value">
    </LINK>
-   <NODE systemname="Camera (Transform Softimage)" filename="%VVVV%\modules\vvvv group\Transform\Camera (Transform Softimage).v4p" nodename="Camera (Transform Softimage)" componentmode="Hidden" id="15">
-   <BOUNDS type="Node" left="7620" top="915" width="100" height="100">
+   <NODE componentmode="Hidden" filename="%VVVV%\modules\vvvv group\Transform\Camera (Transform Softimage).v4p" id="15" nodename="Camera (Transform Softimage)" systemname="Camera (Transform Softimage)">
+   <BOUNDS height="100" left="7620" top="915" type="Node" width="100">
    </BOUNDS>
    <PIN pinname="View" visible="1">
    </PIN>
    <PIN pinname="Projection" visible="1">
    </PIN>
    </NODE>
-   <NODE nodename="IOBox (Node)" componentmode="InABox" id="16" systemname="IOBox (Node)">
-   <BOUNDS type="Node" left="5535" top="4065" width="0" height="0">
+   <NODE componentmode="InABox" id="16" nodename="IOBox (Node)" systemname="IOBox (Node)">
+   <BOUNDS height="0" left="5535" top="4065" type="Node" width="0">
    </BOUNDS>
-   <BOUNDS type="Box" left="5535" top="4065" width="795" height="240">
+   <BOUNDS height="240" left="5535" top="4065" type="Box" width="795">
    </BOUNDS>
-   <PIN pinname="Descriptive Name" slicecount="1" values="Projection" encoded="0">
+   <PIN encoded="0" pinname="Descriptive Name" slicecount="1" values="Projection">
    </PIN>
    <PIN pinname="Input Node" visible="1">
    </PIN>
    </NODE>
-   <NODE systemname="Cons (Transform)" filename="%VVVV%\plugins\SpreadOperations.dll" nodename="Cons (Transform)" componentmode="Hidden" id="4">
-   <BOUNDS type="Node" left="3015" top="3405" width="100" height="100">
+   <NODE componentmode="Hidden" filename="%VVVV%\plugins\SpreadOperations.dll" id="4" nodename="Cons (Transform)" systemname="Cons (Transform)">
+   <BOUNDS height="100" left="3015" top="2955" type="Node" width="100">
    </BOUNDS>
    <PIN pinname="Input 1" visible="1">
    </PIN>
    <PIN pinname="Output" visible="1">
    </PIN>
-   <BOUNDS type="Box" left="3015" top="3345">
+   <BOUNDS left="3015" top="2895" type="Box">
    </BOUNDS>
    <PIN pinname="Input 2" visible="1">
    </PIN>
    <PIN pinname="Switch" visible="1">
    </PIN>
    </NODE>
-   <LINK srcnodeid="15" srcpinname="View" dstnodeid="4" dstpinname="Input 2" linkstyle="Bezier" hiddenwhenlocked="1">
-   <LINKPOINT x="7785" y="2280">
+   <LINK dstnodeid="4" dstpinname="Input 2" hiddenwhenlocked="1" linkstyle="Bezier" srcnodeid="15" srcpinname="View">
+   <LINKPOINT x="7785" y="2130">
    </LINKPOINT>
-   <LINKPOINT x="3570" y="2280">
+   <LINKPOINT x="3570" y="1980">
    </LINKPOINT>
    </LINK>
-   <LINK srcnodeid="4" srcpinname="Output" dstnodeid="10" dstpinname="Input Node">
-   </LINK>
-   <NODE id="12" systemname="UniformScale (Transform)" nodename="UniformScale (Transform)" componentmode="Hidden" hiddenwhenlocked="0" managers="">
-   <PIN pinname="XYZ" visible="1" pintype="Input">
+   <NODE componentmode="Hidden" hiddenwhenlocked="0" id="12" managers="" nodename="UniformScale (Transform)" systemname="UniformScale (Transform)">
+   <PIN pinname="XYZ" pintype="Input" visible="1">
    </PIN>
-   <BOUNDS type="Node" left="3015" top="2805" width="1995" height="270">
+   <BOUNDS height="270" left="3015" top="3405" type="Node" width="1995">
    </BOUNDS>
-   <PIN pinname="Transform Out" visible="1" pintype="Output">
+   <PIN pinname="Transform Out" pintype="Output" visible="1">
    </PIN>
-   <PIN pinname="Transform In" visible="1" pintype="Input">
+   <PIN pinname="Transform In" pintype="Input" visible="1">
    </PIN>
-   <PIN pinname="Descriptive Name" pintype="Configuration" slicecount="1" values="||" encoded="0">
+   <PIN encoded="0" pinname="Descriptive Name" pintype="Configuration" slicecount="1" values="||">
    </PIN>
    <PIN pinname="ID" pintype="Output" visible="-1">
    </PIN>
    </NODE>
-   <LINK srcnodeid="14" srcpinname="Output" dstnodeid="12" dstpinname="XYZ">
+   <LINK dstnodeid="12" dstpinname="XYZ" srcnodeid="14" srcpinname="Output">
    </LINK>
-   <NODE systemname="Cons (Transform)" filename="%VVVV%\plugins\SpreadOperations.dll" nodename="Cons (Transform)" componentmode="Hidden" id="22">
-   <BOUNDS type="Node" left="5535" top="3405" width="100" height="100">
+   <NODE componentmode="Hidden" filename="%VVVV%\plugins\SpreadOperations.dll" id="22" nodename="Cons (Transform)" systemname="Cons (Transform)">
+   <BOUNDS height="100" left="5535" top="3405" type="Node" width="100">
    </BOUNDS>
    <PIN pinname="Input 1" visible="1">
    </PIN>
    <PIN pinname="Output" visible="1">
    </PIN>
-   <BOUNDS type="Box" left="5535" top="3390">
+   <BOUNDS left="5535" top="3390" type="Box">
    </BOUNDS>
    <PIN pinname="Input 2" visible="1">
    </PIN>
    <PIN pinname="Switch" visible="1">
    </PIN>
    </NODE>
-   <LINK srcnodeid="15" srcpinname="Projection" dstnodeid="22" dstpinname="Input 2" linkstyle="Bezier" hiddenwhenlocked="1">
+   <LINK dstnodeid="22" dstpinname="Input 2" hiddenwhenlocked="1" linkstyle="Bezier" srcnodeid="15" srcpinname="Projection">
    <LINKPOINT x="7920" y="2288">
    </LINKPOINT>
    <LINKPOINT x="6090" y="2288">
    </LINKPOINT>
    </LINK>
-   <LINK srcnodeid="22" srcpinname="Output" dstnodeid="16" dstpinname="Input Node">
+   <LINK dstnodeid="16" dstpinname="Input Node" srcnodeid="22" srcpinname="Output">
    </LINK>
-   <NODE systemname="UniformScale (Transform)" nodename="UniformScale (Transform)" componentmode="Hidden" id="24">
-   <BOUNDS type="Node" left="5550" top="2805" width="100" height="100">
+   <NODE componentmode="Hidden" id="24" nodename="UniformScale (Transform)" systemname="UniformScale (Transform)">
+   <BOUNDS height="100" left="5550" top="2805" type="Node" width="100">
    </BOUNDS>
    <PIN pinname="Transform Out" visible="1">
    </PIN>
    <PIN pinname="XYZ" visible="1">
    </PIN>
    </NODE>
-   <LINK srcnodeid="24" srcpinname="Transform Out" dstnodeid="22" dstpinname="Input 1">
+   <LINK dstnodeid="22" dstpinname="Input 1" srcnodeid="24" srcpinname="Transform Out">
    </LINK>
-   <NODE systemname="Select (Value)" nodename="Select (Value)" componentmode="Hidden" id="25">
-   <BOUNDS type="Node" left="6555" top="2385" width="100" height="100">
+   <NODE componentmode="Hidden" id="25" nodename="Select (Value)" systemname="Select (Value)">
+   <BOUNDS height="100" left="6555" top="2385" type="Node" width="100">
    </BOUNDS>
    <PIN pinname="Output" visible="1">
    </PIN>
@@ -240,30 +238,32 @@
    <PIN pinname="Select" slicecount="1" values="3">
    </PIN>
    </NODE>
-   <LINK srcnodeid="25" srcpinname="Output" dstnodeid="24" dstpinname="XYZ">
+   <LINK dstnodeid="24" dstpinname="XYZ" srcnodeid="25" srcpinname="Output">
    </LINK>
-   <LINK srcnodeid="12" srcpinname="Transform Out" dstnodeid="4" dstpinname="Input 1">
-   </LINK>
-   <LINK srcnodeid="5" srcpinname="Transform Out" dstnodeid="12" dstpinname="Transform In">
-   </LINK>
-   <NODE id="26" systemname="Scale (Transform)" nodename="Scale (Transform)" componentmode="Hidden" hiddenwhenlocked="0" managers="">
-   <BOUNDS type="Node" left="3015" top="360" width="100" height="100">
+   <NODE componentmode="Hidden" hiddenwhenlocked="0" id="26" managers="" nodename="Scale (Transform)" systemname="Scale (Transform)">
+   <BOUNDS height="100" left="3015" top="360" type="Node" width="100">
    </BOUNDS>
-   <PIN pinname="Transform Out" visible="1" pintype="Output">
+   <PIN pinname="Transform Out" pintype="Output" visible="1">
    </PIN>
-   <PIN pinname="Descriptive Name" pintype="Configuration" slicecount="1" values="||" encoded="0">
+   <PIN encoded="0" pinname="Descriptive Name" pintype="Configuration" slicecount="1" values="||">
    </PIN>
-   <PIN pinname="Transform In" pintype="Input" visible="1" slicecount="1" values="||">
+   <PIN pinname="Transform In" pintype="Input" slicecount="1" visible="1" values="||">
    </PIN>
-   <PIN pinname="X" pintype="Input" visible="1" slicecount="1" values="1">
+   <PIN pinname="X" pintype="Input" slicecount="1" visible="1" values="1">
    </PIN>
-   <PIN pinname="Y" pintype="Input" visible="1" slicecount="1" values="1">
+   <PIN pinname="Y" pintype="Input" slicecount="1" visible="1" values="1">
    </PIN>
-   <PIN pinname="Z" pintype="Input" visible="1" slicecount="1" values="0.1">
+   <PIN pinname="Z" pintype="Input" slicecount="1" visible="1" values="0.1">
    </PIN>
    <PIN pinname="ID" pintype="Output" visible="-1">
    </PIN>
    </NODE>
-   <LINK srcnodeid="26" srcpinname="Transform Out" dstnodeid="5" dstpinname="Transform In">
+   <LINK dstnodeid="5" dstpinname="Transform In" srcnodeid="26" srcpinname="Transform Out">
+   </LINK>
+   <LINK srcnodeid="4" srcpinname="Output" dstnodeid="12" dstpinname="Transform In">
+   </LINK>
+   <LINK srcnodeid="12" srcpinname="Transform Out" dstnodeid="10" dstpinname="Input Node">
+   </LINK>
+   <LINK srcnodeid="5" srcpinname="Transform Out" dstnodeid="4" dstpinname="Input 1">
    </LINK>
    </PATCH>

--- a/vvvv45/addonpack/lib/nodes/modules/Transform/FourRooms (Transform Viewport).v4p
+++ b/vvvv45/addonpack/lib/nodes/modules/Transform/FourRooms (Transform Viewport).v4p
@@ -1,0 +1,269 @@
+<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45beta26.dtd" >
+   <PATCH nodename="C:\kimchiandchips\VVVV.Research\vvvv-sdk\vvvv45\addonpack\lib\nodes\modules\Transform\FourRooms (Transform Viewport).v4p" filename="C:\kimchiandchips\VVVV.Research\vvvv-sdk\vvvv45\addonpack\lib\nodes\modules\3d\FourRooms (Transform Viewport).v4p" systemname="FourRooms (Transform Viewport)">
+   <BOUNDS height="5400" left="16110" top="7425" type="Window" width="9780">
+   </BOUNDS>
+   <NODE componentmode="InABox" id="0" nodename="IOBox (Node)" systemname="IOBox (Node)">
+   <BOUNDS height="100" left="585" top="270" type="Node" width="100">
+   </BOUNDS>
+   <BOUNDS height="240" left="585" top="270" type="Box" width="795">
+   </BOUNDS>
+   <PIN pinname="Output Node" visible="1">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Layer" encoded="0">
+   </PIN>
+   </NODE>
+   <NODE componentmode="Hidden" id="1" nodename="Group (EX9)" systemname="Group (EX9)">
+   <BOUNDS height="100" left="315" top="3405" type="Node" width="100">
+   </BOUNDS>
+   <PIN pinname="Layer 2" slicecount="1" visible="1" values="||">
+   </PIN>
+   <PIN pinname="Layer 1" visible="1">
+   </PIN>
+   <PIN pinname="Layer" visible="1">
+   </PIN>
+   </NODE>
+   <LINK dstnodeid="1" dstpinname="Layer 2" srcnodeid="0" srcpinname="Output Node">
+   </LINK>
+   <NODE componentmode="Hidden" filename="%VVVV%\modules\vvvv group\EX9\AxisAndGrid (DX9).v4p" id="2" nodename="AxisAndGrid (DX9)" systemname="AxisAndGrid (DX9)">
+   <BOUNDS height="100" left="300" top="2595" type="Node" width="100">
+   </BOUNDS>
+   <PIN pinname="Layer" visible="1">
+   </PIN>
+   <BOUNDS type="Box" left="300" top="2595">
+   </BOUNDS>
+   </NODE>
+   <LINK dstnodeid="1" dstpinname="Layer 1" srcnodeid="2" srcpinname="Layer">
+   </LINK>
+   <NODE systemname="IOBox (Node)" nodename="IOBox (Node)" componentmode="InABox" id="3">
+   <BOUNDS type="Node" left="300" top="4065" width="100" height="100">
+   </BOUNDS>
+   <BOUNDS type="Box" left="300" top="4065" width="795" height="240">
+   </BOUNDS>
+   <PIN pinname="Input Node" visible="1">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Layer" encoded="0">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="1" srcpinname="Layer" dstnodeid="3" dstpinname="Input Node">
+   </LINK>
+   <NODE systemname="Rotate (Transform Vector)" nodename="Rotate (Transform Vector)" componentmode="Hidden" id="5">
+   <BOUNDS type="Node" left="3015" top="2055" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="XYZ" visible="1">
+   </PIN>
+   <PIN pinname="Transform Out" visible="1">
+   </PIN>
+   <PIN pinname="Transform In" visible="1">
+   </PIN>
+   </NODE>
+   <NODE systemname="PeakSpread (Spreads)" nodename="PeakSpread (Spreads)" componentmode="Hidden" id="6">
+   <BOUNDS type="Node" left="3600" top="1185" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <PIN pinname="Spread Count" slicecount="1" values="3">
+   </PIN>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   </NODE>
+   <NODE systemname="I (Spreads)" nodename="I (Spreads)" componentmode="Hidden" id="7">
+   <BOUNDS type="Node" left="3615" top="720" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <PIN pinname=".. To [" slicecount="1" values="3">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="7" srcpinname="Output" dstnodeid="6" dstpinname="Input">
+   </LINK>
+   <NODE systemname="MultiViewport (EX9)" filename="%VVVV%\modules\vvvv group\EX9\MultiViewport (EX9).v4p" nodename="MultiViewport (EX9)" componentmode="Hidden" id="8">
+   <BOUNDS type="Node" left="7515" top="3405" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Screen Count Y" slicecount="1" values="2">
+   </PIN>
+   <BOUNDS type="Box" left="7515" top="3405">
+   </BOUNDS>
+   </NODE>
+   <NODE nodename="IOBox (Node)" componentmode="InABox" id="9" systemname="IOBox (Node)">
+   <BOUNDS type="Node" left="7515" top="4065" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="7515" top="4065" width="795" height="240">
+   </BOUNDS>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Viewports" encoded="0">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="8" srcpinname="Viewports" dstnodeid="9" dstpinname="Input Node">
+   </LINK>
+   <NODE nodename="IOBox (Node)" componentmode="InABox" id="10" systemname="IOBox (Node)">
+   <BOUNDS type="Node" left="3015" top="4065" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="3015" top="4065" width="795" height="240">
+   </BOUNDS>
+   <PIN pinname="Descriptive Name" slicecount="1" values="View" encoded="0">
+   </PIN>
+   <PIN pinname="Input Node" visible="1">
+   </PIN>
+   </NODE>
+   <NODE systemname="Divide (Value)" nodename="Divide (Value)" componentmode="Hidden" id="11">
+   <BOUNDS type="Node" left="3600" top="1650" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <PIN pinname="Input 2" slicecount="1" values="4">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="6" srcpinname="Output" dstnodeid="11" dstpinname="Input">
+   </LINK>
+   <LINK srcnodeid="11" srcpinname="Output" dstnodeid="5" dstpinname="XYZ">
+   </LINK>
+   <NODE systemname="IOBox (Value Advanced)" nodename="IOBox (Value Advanced)" componentmode="InABox" id="13">
+   <BOUNDS type="Node" left="5205" top="270" width="100" height="100">
+   </BOUNDS>
+   <BOUNDS type="Box" left="5205" top="270" width="795" height="240">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" values="5">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Scale" encoded="0">
+   </PIN>
+   <PIN pinname="Y Output Value" visible="1">
+   </PIN>
+   </NODE>
+   <NODE systemname="Divide (Value)" nodename="Divide (Value)" componentmode="Hidden" id="14">
+   <BOUNDS type="Node" left="4950" top="1575" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input 2" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <PIN pinname="Input" slicecount="1" values="2">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="13" srcpinname="Y Output Value" dstnodeid="14" dstpinname="Input 2">
+   </LINK>
+   <NODE systemname="Camera (Transform Softimage)" filename="%VVVV%\modules\vvvv group\Transform\Camera (Transform Softimage).v4p" nodename="Camera (Transform Softimage)" componentmode="Hidden" id="15">
+   <BOUNDS type="Node" left="7620" top="915" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="View" visible="1">
+   </PIN>
+   <PIN pinname="Projection" visible="1">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (Node)" componentmode="InABox" id="16" systemname="IOBox (Node)">
+   <BOUNDS type="Node" left="5535" top="4065" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="5535" top="4065" width="795" height="240">
+   </BOUNDS>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Projection" encoded="0">
+   </PIN>
+   <PIN pinname="Input Node" visible="1">
+   </PIN>
+   </NODE>
+   <NODE systemname="Cons (Transform)" filename="%VVVV%\plugins\SpreadOperations.dll" nodename="Cons (Transform)" componentmode="Hidden" id="4">
+   <BOUNDS type="Node" left="3015" top="3405" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input 1" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <BOUNDS type="Box" left="3015" top="3345">
+   </BOUNDS>
+   <PIN pinname="Input 2" visible="1">
+   </PIN>
+   <PIN pinname="Switch" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="15" srcpinname="View" dstnodeid="4" dstpinname="Input 2" linkstyle="Bezier" hiddenwhenlocked="1">
+   <LINKPOINT x="7785" y="2280">
+   </LINKPOINT>
+   <LINKPOINT x="3570" y="2280">
+   </LINKPOINT>
+   </LINK>
+   <LINK srcnodeid="4" srcpinname="Output" dstnodeid="10" dstpinname="Input Node">
+   </LINK>
+   <NODE id="12" systemname="UniformScale (Transform)" nodename="UniformScale (Transform)" componentmode="Hidden" hiddenwhenlocked="0" managers="">
+   <PIN pinname="XYZ" visible="1" pintype="Input">
+   </PIN>
+   <BOUNDS type="Node" left="3015" top="2805" width="1995" height="270">
+   </BOUNDS>
+   <PIN pinname="Transform Out" visible="1" pintype="Output">
+   </PIN>
+   <PIN pinname="Transform In" visible="1" pintype="Input">
+   </PIN>
+   <PIN pinname="Descriptive Name" pintype="Configuration" slicecount="1" values="||" encoded="0">
+   </PIN>
+   <PIN pinname="ID" pintype="Output" visible="-1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="14" srcpinname="Output" dstnodeid="12" dstpinname="XYZ">
+   </LINK>
+   <NODE systemname="Cons (Transform)" filename="%VVVV%\plugins\SpreadOperations.dll" nodename="Cons (Transform)" componentmode="Hidden" id="22">
+   <BOUNDS type="Node" left="5535" top="3405" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input 1" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <BOUNDS type="Box" left="5535" top="3390">
+   </BOUNDS>
+   <PIN pinname="Input 2" visible="1">
+   </PIN>
+   <PIN pinname="Switch" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="15" srcpinname="Projection" dstnodeid="22" dstpinname="Input 2" linkstyle="Bezier" hiddenwhenlocked="1">
+   <LINKPOINT x="7920" y="2288">
+   </LINKPOINT>
+   <LINKPOINT x="6090" y="2288">
+   </LINKPOINT>
+   </LINK>
+   <LINK srcnodeid="22" srcpinname="Output" dstnodeid="16" dstpinname="Input Node">
+   </LINK>
+   <NODE systemname="UniformScale (Transform)" nodename="UniformScale (Transform)" componentmode="Hidden" id="24">
+   <BOUNDS type="Node" left="5550" top="2805" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Transform Out" visible="1">
+   </PIN>
+   <PIN pinname="XYZ" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="24" srcpinname="Transform Out" dstnodeid="22" dstpinname="Input 1">
+   </LINK>
+   <NODE systemname="Select (Value)" nodename="Select (Value)" componentmode="Hidden" id="25">
+   <BOUNDS type="Node" left="6555" top="2385" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <PIN pinname="Input" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="Select" slicecount="1" values="3">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="25" srcpinname="Output" dstnodeid="24" dstpinname="XYZ">
+   </LINK>
+   <LINK srcnodeid="12" srcpinname="Transform Out" dstnodeid="4" dstpinname="Input 1">
+   </LINK>
+   <LINK srcnodeid="5" srcpinname="Transform Out" dstnodeid="12" dstpinname="Transform In">
+   </LINK>
+   <NODE id="26" systemname="Scale (Transform)" nodename="Scale (Transform)" componentmode="Hidden" hiddenwhenlocked="0" managers="">
+   <BOUNDS type="Node" left="3015" top="360" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Transform Out" visible="1" pintype="Output">
+   </PIN>
+   <PIN pinname="Descriptive Name" pintype="Configuration" slicecount="1" values="||" encoded="0">
+   </PIN>
+   <PIN pinname="Transform In" pintype="Input" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="X" pintype="Input" visible="1" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="Y" pintype="Input" visible="1" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="Z" pintype="Input" visible="1" slicecount="1" values="0.1">
+   </PIN>
+   <PIN pinname="ID" pintype="Output" visible="-1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="26" srcpinname="Transform Out" dstnodeid="5" dstpinname="Transform In">
+   </LINK>
+   </PATCH>


### PR DESCRIPTION
As an alternative to the existing FourRooms, all 4 views are given in 1 renderer, which exists outside of the module. This gives the user more control of the renderer.

also this is a test of a pull request to see how it works with vvvv

<3's and diamonds
Elliot
