### PR TITLE
Startable changes.

### DIFF
--- a/vvvv45/src/core/Hosting/Factories/DotNetPluginFactory.cs
+++ b/vvvv45/src/core/Hosting/Factories/DotNetPluginFactory.cs
@@ -92,6 +92,11 @@ namespace VVVV.Hosting.Factories
 
         public event PluginCreatedDelegate PluginCreated;
         public event PluginDeletedDelegate PluginDeleted;
+
+        public StartableRegistry StartableRegistry
+        {
+            get { return this.FStartableRegistry; }
+        }
         
         public override string JobStdSubPath
         {
@@ -234,7 +239,7 @@ namespace VVVV.Hosting.Factories
                     nodeInfo.CommitUpdate();
             }
         }
-        
+
         private static CustomAttributeData GetPluginInfoAttributeData(Type type)
         {
             var attributes = CustomAttributeData.GetCustomAttributes(type).Where(ca => ca.Constructor.DeclaringType.FullName == typeof(PluginInfoAttribute).FullName).ToArray();

--- a/vvvv45/src/core/Hosting/Factories/StartableRegistry.cs
+++ b/vvvv45/src/core/Hosting/Factories/StartableRegistry.cs
@@ -4,13 +4,27 @@ using System.Linq;
 using System.Text;
 using System.Reflection;
 using VVVV.PluginInterfaces.V2;
+using System.Diagnostics;
 
 namespace VVVV.Hosting.Factories
 {
+    public class StartableInfo
+    {
+        public Type Type { get; set; }
+        public string Name { get; set; }
+    }
+
+    public class StartableStatus
+    {
+        public IStartable Startable { get; set; }
+        public bool Success { get; set; }
+        public string Message { get; set; }
+        public StartableInfo Info { get; set; }
+    }
+
     public class StartableRegistry
     {
-
-        class StartableInterfaces : List<Type> { }
+        class StartableInterfaces : List<StartableInfo> { }
 
         class StartableCache : Dictionary<string, StartableInterfaces> { }
 
@@ -19,6 +33,13 @@ namespace VVVV.Hosting.Factories
         private StartableCache FStartable = new StartableCache();
 
         private List<string> FProcessedAssemblies = new List<string>();
+
+        private List<StartableStatus> FStarted = new List<StartableStatus>();
+
+        public List<StartableStatus> Status
+        {
+            get { return FStarted; }
+        }
 
         public StartableRegistry(Assembly pluginInterfacesAssembly)
         {
@@ -44,25 +65,45 @@ namespace VVVV.Hosting.Factories
                         namedArguments[namedArgument.MemberInfo.Name] = namedArgument.TypedValue.Value;
                     }
 
-                    StartableInterfaces ifaces;
+                    StartableInterfaces infos;
                     if (!FStartable.ContainsKey(assembly.FullName))
                     {
-                        ifaces = new StartableInterfaces();
-                        FStartable[assembly.FullName] = ifaces;
+                        infos = new StartableInterfaces();
+                        FStartable[assembly.FullName] = infos;
                     }
                     else
                     {
-                        ifaces = FStartable[assembly.FullName];
+                        infos = FStartable[assembly.FullName];
                     }
 
-                    ifaces.Add(type);
+                    StartableInfo info = new StartableInfo();
+                    info.Type = type;
 
                     bool lazy = true;
                     if (namedArguments.ContainsKey("Lazy"))
                     {
-                        lazy = bool.Parse(namedArguments["Lazy"].ToString());
+                        try
+                        {
+                            lazy = bool.Parse(namedArguments["Lazy"].ToString());
+                        }
+                        catch
+                        {
+                            //Lazy by default
+                            lazy = true;
+                        }
                     }
-                    //bool lazy = (bool)namedArguments("Lazy");
+
+                    if (namedArguments.ContainsKey("Name"))
+                    {
+                        info.Name = namedArguments["Name"].ToString();
+                    }
+                    else
+                    {
+                        info.Name = type.FullName;
+                    }
+
+                    infos.Add(info);
+
                     if (!lazy) { nonLazyStartable = true; }
                 }
             }
@@ -75,14 +116,48 @@ namespace VVVV.Hosting.Factories
             {
                 if (!FProcessedAssemblies.Contains(assembly.FullName))
                 {
-                    foreach (Type t in FStartable[assembly.FullName])
+                    foreach (StartableInfo info in FStartable[assembly.FullName])
                     {
-                        object startable = assembly.CreateInstance(t.FullName);
-                        ((IStartable)startable).Start();
+                        object o = assembly.CreateInstance(info.Type.FullName);
+
+                        StartableStatus s = new StartableStatus();
+                        s.Startable = (IStartable)o;
+                        s.Info = info;
+
+                        try
+                        {
+                            s.Startable.Start();
+                            s.Success = true;
+                            s.Message = "OK";
+                        }
+                        catch (Exception ex)
+                        {
+                            s.Success = false;
+                            s.Message = ex.Message;
+                        }
+
+                        this.FStarted.Add(s);
                     }
                     FProcessedAssemblies.Add(assembly.FullName);
                 }
             }
+        }
+
+        public void ShutDown()
+        {
+            foreach (StartableStatus s in this.FStarted)
+            {
+                try
+                {
+                    s.Startable.Shutdown();
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine("Failed to stop: " + ex.Message);
+                }
+            }
+            //Shouldnt be needed, but clears references;
+            this.FStarted.Clear();
         }
 
         private static CustomAttributeData GetStartableAttributeData(Type type)

--- a/vvvv45/src/core/Hosting/HDEHost.cs
+++ b/vvvv45/src/core/Hosting/HDEHost.cs
@@ -271,7 +271,7 @@ namespace VVVV.Hosting
         
         public void Shutdown()
         {
-            // Call shutdown method of StartableRegistry here
+            PluginFactory.StartableRegistry.ShutDown();
         }
 
         #endregion IInternalHDEHost

--- a/vvvv45/src/core/PluginInterfaces/V2/StartableAttribute.cs
+++ b/vvvv45/src/core/PluginInterfaces/V2/StartableAttribute.cs
@@ -12,6 +12,15 @@ namespace VVVV.PluginInterfaces.V2
     [ComVisible(false)]
     public class StartableAttribute : ExportAttribute
     {
+        /// <summary>
+        /// Friendly name for Startable Elements
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// If Lazy, it will only start when assemly loads, 
+        /// otherwise it will force assmebly to load on startup
+        /// </summary>
         public bool Lazy { get; set; }
     }
 }

--- a/vvvv45/src/nodes/plugins/NativePlugins.csproj
+++ b/vvvv45/src/nodes/plugins/NativePlugins.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <PropertyGroup>
     <ProjectGuid>{716F4773-5590-4DD6-A9BC-3FE905D22DA5}</ProjectGuid>
@@ -101,7 +101,9 @@
     <Compile Include="Spreads\Lindenmayer\Lindenmayer.cs" />
     <Compile Include="Spreads\Lindenmayer\LindenmayerNode.cs" />
     <Compile Include="SVG\SVGGeomNodes.cs" />
-    <Compile Include="SVG\SVGTextureNode.cs" />
+    <Compile Include="SVG\SVGTextureNode.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
     <Compile Include="Transform\Decompose\DecomposeNode.cs" />
     <Compile Include="Value\DifferentialNode.cs" />
     <Compile Include="Value\IntegralNode.cs" />
@@ -168,6 +170,7 @@
     <Compile Include="vvvv\ProjectExplorer\ProjectExplorerPlugin.Designer.cs">
       <DependentUpon>ProjectExplorerPlugin.cs</DependentUpon>
     </Compile>
+    <Compile Include="vvvv\StartableInfo\StartableInfoNode.cs" />
     <Compile Include="vvvv\WindowSwitcher\WindowSwitcherNode.cs">
       <SubType>UserControl</SubType>
     </Compile>

--- a/vvvv45/src/nodes/plugins/vvvv/StartableInfo/StartableInfoNode.cs
+++ b/vvvv45/src/nodes/plugins/vvvv/StartableInfo/StartableInfoNode.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using VVVV.PluginInterfaces.V2;
+using VVVV.PluginInterfaces.V1;
+using VVVV.Hosting.Factories;
+using System.ComponentModel.Composition;
+
+namespace VVVV.Nodes.vvvv.StartableInfo
+{
+    [PluginInfo(Name="Info",Category="VVVV",Version="Startables",Author="vux",Help="Returns info about any autostart modules in VVVV")]
+    public class StartableInfoNode : IPluginEvaluate
+    {
+        [Input("Update", IsSingle = true, IsBang = true)]
+        ISpread<bool> FInUpdate;
+
+        [Output("Name")]
+        ISpread<string> FOutName;
+
+        [Output("Is Started")]
+        ISpread<bool> FOutStarted;
+
+        [Output("Message")]
+        ISpread<string> FOutMessage;
+
+        [Output("Type Name",Visibility=PinVisibility.Hidden)]
+        ISpread<string> FOutTypeName;
+
+        DotNetPluginFactory FDNFactory;
+
+        bool FFirstFrame = true;
+
+        [ImportingConstructor()]
+        public StartableInfoNode(DotNetPluginFactory dnFactory)
+        {
+            FDNFactory = dnFactory;
+        }
+
+        public void Evaluate(int SpreadMax)
+        {
+            if (FInUpdate[0] || FFirstFrame)
+            {
+                List<StartableStatus> status = FDNFactory.StartableRegistry.Status;
+                int cnt = status.Count;
+                FOutMessage.SliceCount = cnt;
+                FOutName.SliceCount = cnt;
+                FOutStarted.SliceCount = cnt;
+                FOutTypeName.SliceCount = cnt;
+
+                for (int i = 0; i < cnt; i++)
+                {
+                    StartableStatus s = status[i];
+                    FOutTypeName[i] = s.Info.Type.FullName;
+                    FOutStarted[i] = s.Success;
+                    FOutMessage[i] = s.Message;
+                    FOutName[i] = s.Info.Name;
+                }
+
+                FFirstFrame = false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
-Dot Net factory exposes Startable registry.
-Startable registry keeps more info about statuses.
-HDE Host ShutDown stops all Startable Interfaces.
-Startable Attribute Now exposes a friendly name.
-Added Info (VVVV Startables) node, to know what's started and status.
