### PR TITLE
GetElements += >Name output-pin

### DIFF
--- a/vvvv45/src/nodes/plugins/SVG/SVGGeomNodes.cs
+++ b/vvvv45/src/nodes/plugins/SVG/SVGGeomNodes.cs
@@ -562,7 +562,7 @@ namespace VVVV.Nodes
 		}
 	}
 	
-	//GETPATH-------------------------------------------------------------------
+	//GETELEMENTS-------------------------------------------------------------------
 	#region PluginInfo
 	[PluginInfo(Name = "GetElements", 
 	            Category = "SVG", 
@@ -578,6 +578,9 @@ namespace VVVV.Nodes
 		[Output("Element")]
 		ISpread<SvgElement> FElementsOut;
 		
+		[Output("Name")]
+		ISpread<string> FName;
+		
 		[Output("Type")]
 		ISpread<string> FElementTypeOut;
 		
@@ -592,6 +595,7 @@ namespace VVVV.Nodes
 				FElementsOut.SliceCount = 0;
 				FElementTypeOut.SliceCount = 0;
 				FElementLevelOut.SliceCount = 0;
+				FName.SliceCount = 0;
 				
 				for(int i=0; i<SpreadMax; i++)
 				{
@@ -607,6 +611,7 @@ namespace VVVV.Nodes
 			FElementsOut.Add(elem);
 			FElementTypeOut.Add(elem.GetType().Name.Replace("Svg", ""));
 			FElementLevelOut.Add(level);
+			FName.Add(elem.ID);
 			
 			foreach(var child in elem.Children)
 			{


### PR DESCRIPTION
GetElements (SVG) has a ne Output-Pin: Name (e.g. = the layer name in illustrator)

that was usefull for me, avoiding a separate Xpath node
