### PR TITLE
First quick fix for virmata to work with alpha28.4 with unicorn and raw ...

### DIFF
--- a/vvvv45/addonpack/lib/nodes/modules/Devices/Arduino (Devices StandardFirmata 2.x) help.v4p
+++ b/vvvv45/addonpack/lib/nodes/modules/Devices/Arduino (Devices StandardFirmata 2.x) help.v4p
@@ -1,5 +1,5 @@
-<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45alpha28.dtd" >
-   <PATCH nodename="C:\Users\horst\DEV\vvvv-plugins\vvvirmata\modules\Arduino (Devices StandardFirmata 2.x) help.v4p" bgcolor="15329769" filename="C:\Users\jens\devel\v4plugins\VirmataEncoder\Arduino (Devices StandardFirmata 2.x) (help).v4p" systemname="Arduino (Devices StandardFirmata 2.x)">
+<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45alpha28.4.dtd" >
+   <PATCH nodename="C:\Users\horst\DEV\vvvv-sdk\vvvv45\addonpack\lib\nodes\modules\Devices\Arduino (Devices StandardFirmata 2.x) help.v4p" bgcolor="15329769" filename="C:\Users\jens\devel\v4plugins\VirmataEncoder\Arduino (Devices StandardFirmata 2.x) (help).v4p" systemname="Arduino (Devices StandardFirmata 2.x)">
    <BOUNDS height="12630" left="0" top="0" type="Window" width="11175">
    </BOUNDS>
    <NODE componentmode="InABox" id="101" nodename="IOBox (Value Advanced)" systemname="IOBox (Value Advanced)">
@@ -445,7 +445,7 @@
    </BOUNDS>
    <BOUNDS height="375" left="9210" top="75" type="Box" width="1845">
    </BOUNDS>
-   <PIN encoded="0" pinname="Input String" slicecount="1" visible="0" values="|Version: 1.0|">
+   <PIN encoded="0" pinname="Input String" slicecount="1" visible="0" values="|Version: 1.0.1|">
    </PIN>
    <PIN pinname="Output String" visible="0">
    </PIN>
@@ -529,9 +529,9 @@
    <NODE componentmode="InABox" id="134" nodename="IOBox (String)" systemname="IOBox (String)">
    <BOUNDS height="270" left="6075" top="2130" type="Node" width="795">
    </BOUNDS>
-   <BOUNDS height="1830" left="6075" top="2130" type="Box" width="4905">
+   <BOUNDS height="4800" left="6075" top="2130" type="Box" width="5205">
    </BOUNDS>
-   <PIN encoded="0" pinname="Input String" slicecount="1" visible="0" values="|Features:&cr;&lf;&cr;&lf;- Analog I/O&cr;&lf;- Digital I/O&cr;&lf;- PWM (set pinmode and send a values from 0 to 1)&cr;&lf;- Servo  (set pinmode and send a values from 0 to 1)&cr;&lf;- Set an individual sample rate for the ananlog pins (see Inspektor)&cr;&lf;- (experimental) support for I2C data decoding|">
+   <PIN encoded="0" pinname="Input String" slicecount="1" visible="0" values="|Features:&cr;&lf;&cr;&lf;- Analog I/O&cr;&lf;- Digital I/O&cr;&lf;- PWM (set pinmode and send a values from 0 to 1)&cr;&lf;- Servo  (set pinmode and send a values from 0 to 1)&cr;&lf;- Set an individual sample rate for the ananlog pins (see Inspektor)&cr;&lf;- (experimental) support for I2C data decoding&cr;&lf;&cr;&lf;&cr;&lf;**NEW in version 1.0.1**&cr;&lf;&cr;&lf;This is  a maintainance release.&cr;&lf;&cr;&lf;Quickfix support for new Raw data type and therefor&cr;&lf;no problems with unicorn!&cr;&lf;&cr;&lf;Supports to set a variable Wait For Reset time via Inspector (useful&cr;&lf;if you have a slow board, e.g. the Boarduino)|">
    </PIN>
    <PIN pinname="Output String" visible="0">
    </PIN>

--- a/vvvv45/addonpack/lib/nodes/modules/Devices/Arduino (Devices StandardFirmata 2.x).v4p
+++ b/vvvv45/addonpack/lib/nodes/modules/Devices/Arduino (Devices StandardFirmata 2.x).v4p
@@ -1,4 +1,4 @@
-<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45alpha28.dtd" >
+<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45alpha28.4.dtd" >
    <PATCH nodename="C:\Users\horst\DEV\vvvv-sdk\vvvv45\addonpack\lib\nodes\modules\Devices\Arduino (Devices StandardFirmata 2.x).v4p" filename="C:\Users\jens\devel\v4plugins\VirmataEncoder\Arduino (Devices StandardFirmata 2.x).v4p" systemname="Arduino (Devices StandardFirmata 2.x)">
    <BOUNDS height="11910" left="11160" top="120" type="Window" width="8985">
    </BOUNDS>
@@ -50,7 +50,7 @@
    <PIN encoded="0" pinname="Descriptive Name" slicecount="1" values="ReportDigital">
    </PIN>
    </NODE>
-   <NODE componentmode="Hidden" filename="" id="10" nodename="RS232 (Devices)" systemname="RS232 (Devices)">
+   <NODE componentmode="Hidden" filename="" id="10" nodename="RS232 (Devices)" systemname="RS232 (Devices String)">
    <BOUNDS height="270" left="1275" top="9075" type="Node" width="3420">
    </BOUNDS>
    <PIN pinname="Input" visible="1">
@@ -70,6 +70,8 @@
    <PIN pinname="Baud Rate" slicecount="1" visible="1" values="57600">
    </PIN>
    <PIN pinname="IsConnected" visible="1">
+   </PIN>
+   <PIN pinname="Encoding" slicecount="1" values="windows-1250">
    </PIN>
    </NODE>
    <NODE componentmode="InABox" id="9" nodename="IOBox (Enumerations)" systemname="IOBox (Enumerations)">
@@ -311,7 +313,7 @@
    </BOUNDS>
    <BOUNDS height="240" left="6870" top="2445" type="Box" width="510">
    </BOUNDS>
-   <PIN pinname="Y Input Value" slicecount="1" values="23">
+   <PIN pinname="Y Input Value" slicecount="1" values="16">
    </PIN>
    <PIN encoded="0" pinname="Units" slicecount="1" values="||">
    </PIN>
@@ -395,7 +397,7 @@
    <NODE systemname="Delay (Animation)" nodename="Delay (Animation)" componentmode="Hidden" id="36">
    <BOUNDS type="Node" left="6855" top="9105" width="100" height="100">
    </BOUNDS>
-   <PIN pinname="Time" slicecount="1" values="5">
+   <PIN pinname="Time" slicecount="1" values="10">
    </PIN>
    <PIN pinname="Input" visible="1">
    </PIN>
@@ -551,7 +553,7 @@
    </BOUNDS>
    <BOUNDS height="375" left="6390" top="795" type="Box" width="1845">
    </BOUNDS>
-   <PIN encoded="0" pinname="Input String" slicecount="1" visible="0" values="|Version: 1.0|">
+   <PIN encoded="0" pinname="Input String" slicecount="1" visible="0" values="|Version: 1.0.1|">
    </PIN>
    <PIN pinname="Output String" visible="0">
    </PIN>
@@ -573,5 +575,29 @@
    <LINK srcnodeid="36" srcpinname="Output" dstnodeid="38" dstpinname="Input 1">
    </LINK>
    <LINK srcnodeid="38" srcpinname="Output" dstnodeid="23" dstpinname="Input 2">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="40" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Node" left="7035" top="7470" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="7035" top="7470" width="795" height="240">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" values="8">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="s">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="|Wait for Reset|">
+   </PIN>
+   <PIN pinname="Pin Visibility" slicecount="1" values="OnlyInspector">
+   </PIN>
+   <PIN pinname="Minimum" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Default" slicecount="1" values="8">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Integer">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="40" srcpinname="Y Output Value" dstnodeid="36" dstpinname="Time">
    </LINK>
    </PATCH>


### PR DESCRIPTION
As the implementation fo the new Raw data (like!) type is takes time this is a quick fixso the plugin works in the modules with the latest alpha.

It simply uses the encoding setting on the rs232 node to convert from ANSI.

A detailed implementation will follow with more fixes and features in the 1.1.x versions.

greetz! jns
