### PR TITLE
Fixes and normalizations on the MIDI modules

### DIFF
--- a/vvvv45/lib/nodes/modules/Devices/MidiAllNotesOff (Devices).v4p
+++ b/vvvv45/lib/nodes/modules/Devices/MidiAllNotesOff (Devices).v4p
@@ -1,6 +1,6 @@
-<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45debug29.1.dtd" >
-   <PATCH nodename="C:\Dev\vvvv\vvvv\public\vvvv45\lib\nodes\modules\Devices\MidiAllNotesOff (Devices).v4p">
-   <BOUNDS height="6000" left="14370" top="9915" type="Window" width="9000">
+<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45alpha29.3.dtd" >
+   <PATCH nodename="C:\vvvv\git\vvvv-sdk\vvvv45\lib\nodes\modules\Devices\MidiAllNotesOff (Devices).v4p">
+   <BOUNDS height="6000" left="3375" top="7590" type="Window" width="9000">
    </BOUNDS>
    <NODE id="3" nodename="I (Spreads)">
    <BOUNDS height="0" left="2520" top="2955" type="Node" width="0">
@@ -11,11 +11,11 @@
    </PIN>
    </NODE>
    <NODE componentmode="InABox" id="2" nodename="IOBOX (VALUE ADVANCED)">
-   <BOUNDS height="0" left="1395" top="1650" type="Node" width="0">
+   <BOUNDS height="0" left="1995" top="1950" type="Node" width="0">
    </BOUNDS>
    <BOUNDS height="160" left="6495" top="6660" type="Window" width="215">
    </BOUNDS>
-   <BOUNDS height="240" left="1395" top="1650" type="Box" width="795">
+   <BOUNDS height="240" left="1995" top="1950" type="Box" width="795">
    </BOUNDS>
    <PIN pinname="Descriptive Name" slicecount="1" values="Channel">
    </PIN>
@@ -25,13 +25,17 @@
    </PIN>
    <PIN pinname="Value Type" slicecount="1" values="Integer">
    </PIN>
+   <PIN pinname="Minimum" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Maximum" slicecount="1" values="15">
+   </PIN>
    </NODE>
    <NODE componentmode="InABox" id="1" nodename="IOBOX (VALUE ADVANCED)">
-   <BOUNDS height="0" left="1005" top="2190" type="Node" width="0">
+   <BOUNDS height="0" left="855" top="1950" type="Node" width="0">
    </BOUNDS>
    <BOUNDS height="160" left="12045" top="8715" type="Window" width="215">
    </BOUNDS>
-   <BOUNDS height="240" left="1005" top="2190" type="Box" width="795">
+   <BOUNDS height="240" left="855" top="1950" type="Box" width="795">
    </BOUNDS>
    <PIN pinname="Descriptive Name" slicecount="1" values="Send">
    </PIN>
@@ -53,11 +57,11 @@
    </PIN>
    </NODE>
    <NODE componentmode="Hidden" id="0" nodename="C:\Users\joreg\dev\vake\source\complete\vvvv40_DynamicNodes\modules\tonfilms\MidiNoteOut (Devices).v4p">
-   <BOUNDS height="0" left="1740" top="4470" type="Node" width="0">
+   <BOUNDS height="0" left="1920" top="4290" type="Node" width="0">
    </BOUNDS>
    <BOUNDS height="6000" left="6300" top="13065" type="Window" width="9000">
    </BOUNDS>
-   <BOUNDS height="3600" left="1740" top="4470" type="Box" width="4800">
+   <BOUNDS height="3600" left="1920" top="4290" type="Box" width="4800">
    </BOUNDS>
    <PIN pinname="Play" visible="1">
    </PIN>
@@ -76,4 +80,36 @@
    </LINK>
    <INFO author="tonfilm" description="module to send a all note off message" tags="io, panic">
    </INFO>
+   <NODE nodename="IOBox (Enumerations)" componentmode="InABox" id="4" systemname="IOBox (Enumerations)">
+   <BOUNDS type="Node" left="4140" top="1950" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="4140" top="1950" width="1590" height="240">
+   </BOUNDS>
+   <PIN pinname="Input Enum" slicecount="1" values="|Microsoft GS Wavetable Synth|">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="|Midi Output Port|">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="4" srcpinname="Output Enum" dstnodeid="0" dstpinname="Midi Output Port">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="5" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Node" left="3405" top="1800" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="3405" top="1800" width="480" height="480">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Boolean">
+   </PIN>
+   <PIN pinname="Behavior" slicecount="1" values="Toggle">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Enabled">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="5" srcpinname="Y Output Value" dstnodeid="0" dstpinname="Enabled">
+   </LINK>
    </PATCH>

--- a/vvvv45/lib/nodes/modules/Devices/MidiControllerOut (Devices).v4p
+++ b/vvvv45/lib/nodes/modules/Devices/MidiControllerOut (Devices).v4p
@@ -1,6 +1,6 @@
-<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45debug29.1.dtd" >
-   <PATCH nodename="C:\Dev\vvvv\vvvv\public\vvvv45\lib\nodes\modules\Devices\MidiControllerOut (Devices).v4p" systemname="MidiControllerOut (Devices)" filename="C:\Dev\vvvv\vvvv\public\vvvv45\lib\nodes\modules\Devices\MidiControllerOut (Devices).v4p">
-   <BOUNDS height="6000" left="3315" top="8505" type="Window" width="9375">
+<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45alpha29.3.dtd" >
+   <PATCH nodename="C:\vvvv\git\vvvv-sdk\vvvv45\lib\nodes\modules\Devices\MidiControllerOut (Devices).v4p" systemname="MidiControllerOut (Devices)" filename="C:\Dev\vvvv\vvvv\public\vvvv45\lib\nodes\modules\Devices\MidiControllerOut (Devices).v4p">
+   <BOUNDS height="6000" left="10560" top="4785" type="Window" width="10440">
    </BOUNDS>
    <NODE id="9" nodename="MidiShortOutput (Devices)" systemname="MidiShortOutput (Devices)">
    <BOUNDS height="0" left="2370" top="4380" type="Node" width="0">
@@ -11,23 +11,13 @@
    </PIN>
    <PIN pinname="Midi Output Port" visible="1">
    </PIN>
-   <PIN pinname="Data1" visible="1">
+   <PIN pinname="Data1" visible="1" slicecount="1" values="0">
    </PIN>
    <PIN pinname="Data2" visible="1">
    </PIN>
    <PIN pinname="Enabled" slicecount="1" visible="1" values="1">
    </PIN>
    <PIN pinname="Descriptive Name" slicecount="1" values="||">
-   </PIN>
-   </NODE>
-   <NODE id="8" nodename="Mod (Value)" systemname="Mod (Value)">
-   <BOUNDS height="0" left="2205" top="1965" type="Node" width="0">
-   </BOUNDS>
-   <PIN pinname="Input 2" slicecount="1" values="16">
-   </PIN>
-   <PIN pinname="Input 1" visible="1">
-   </PIN>
-   <PIN pinname="Output" visible="1">
    </PIN>
    </NODE>
    <NODE componentmode="InABox" id="7" nodename="IOBOX (VALUE ADVANCED)" systemname="IOBox (Value Advanced)">
@@ -43,19 +33,21 @@
    </PIN>
    <PIN pinname="Descriptive Name" slicecount="1" values="Channel">
    </PIN>
-   <PIN pinname="Minimum" slicecount="1" values="1">
+   <PIN pinname="Minimum" slicecount="1" values="0">
    </PIN>
-   <PIN pinname="Maximum" slicecount="1" values="16">
+   <PIN pinname="Maximum" slicecount="1" values="15">
    </PIN>
    <PIN pinname="Value Type" slicecount="1" values="Integer">
    </PIN>
+   <PIN pinname="X Input Value" slicecount="1" values="0">
+   </PIN>
    </NODE>
    <NODE id="6" nodename="Add (Value)" systemname="Add (Value)">
-   <BOUNDS height="0" left="2235" top="2595" type="Node" width="0">
+   <BOUNDS height="0" left="1935" top="2595" type="Node" width="0">
    </BOUNDS>
    <PIN pinname="Input 2" slicecount="1" visible="1" values="176">
    </PIN>
-   <PIN pinname="Input 1" visible="1">
+   <PIN pinname="Input 1" visible="1" slicecount="1" values="0">
    </PIN>
    <PIN pinname="Output" visible="1">
    </PIN>
@@ -77,6 +69,10 @@
    </PIN>
    <PIN pinname="Value Type" slicecount="1" values="Integer">
    </PIN>
+   <PIN pinname="Minimum" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Maximum" slicecount="1" values="119">
+   </PIN>
    </NODE>
    <NODE componentmode="InABox" id="4" nodename="IOBOX (VALUE ADVANCED)" systemname="IOBox (Value Advanced)">
    <BOUNDS height="0" left="3915" top="300" type="Node" width="0">
@@ -91,21 +87,11 @@
    </PIN>
    <PIN pinname="Y Input Value" slicecount="1" values="0.5">
    </PIN>
-   </NODE>
-   <LINK dstnodeid="6" dstpinname="Input 1" srcnodeid="8" srcpinname="Output">
-   </LINK>
-   <NODE id="3" nodename="Mod (Value)" systemname="Mod (Value)">
-   <BOUNDS height="0" left="2955" top="1935" type="Node" width="0">
-   </BOUNDS>
-   <PIN pinname="Input 2" slicecount="1" values="127">
+   <PIN pinname="Minimum" slicecount="1" values="0">
    </PIN>
-   <PIN pinname="Input 1" visible="1">
-   </PIN>
-   <PIN pinname="Output" visible="1">
+   <PIN pinname="Maximum" slicecount="1" values="1">
    </PIN>
    </NODE>
-   <LINK dstnodeid="9" dstpinname="Data1" srcnodeid="3" srcpinname="Output">
-   </LINK>
    <NODE componentmode="InABox" id="2" nodename="IOBox (Enumerations)" systemname="IOBox (Enumerations)">
    <BOUNDS height="0" left="8370" top="450" type="Node" width="0">
    </BOUNDS>
@@ -121,10 +107,6 @@
    </PIN>
    </NODE>
    <LINK dstnodeid="9" dstpinname="Midi Output Port" srcnodeid="2" srcpinname="Output Enum">
-   </LINK>
-   <LINK dstnodeid="3" dstpinname="Input 1" srcnodeid="5" srcpinname="Y Output Value">
-   </LINK>
-   <LINK dstnodeid="8" dstpinname="Input 1" srcnodeid="7" srcpinname="Y Output Value">
    </LINK>
    <NODE id="1" nodename="CHANGE (ANIMATION)" systemname="Change (Animation)">
    <BOUNDS height="0" left="4110" top="2370" type="Node" width="0">
@@ -246,4 +228,82 @@
    </NODE>
    <LINK srcnodeid="14" srcpinname="Y Output Value" dstnodeid="13" dstpinname="Input 2">
    </LINK>
+   <NODE systemname="Frac (Value)" nodename="Frac (Value)" componentmode="Hidden" id="16">
+   <BOUNDS type="Node" left="1560" top="1110" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Whole Part" visible="1">
+   </PIN>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="7" srcpinname="Y Output Value" dstnodeid="16" dstpinname="Input">
+   </LINK>
+   <NODE systemname="Frac (Value)" nodename="Frac (Value)" componentmode="Hidden" id="17">
+   <BOUNDS type="Node" left="2835" top="1215" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Whole Part" visible="1">
+   </PIN>
+   <PIN pinname="Input" visible="1" slicecount="1" values="0">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="5" srcpinname="Y Output Value" dstnodeid="17" dstpinname="Input">
+   </LINK>
+   <NODE id="8" nodename="Mod (Value)" systemname="Mod (Value)">
+   <BOUNDS height="0" left="1905" top="1965" type="Node" width="0">
+   </BOUNDS>
+   <PIN pinname="Input 2" slicecount="1" values="16">
+   </PIN>
+   <PIN pinname="Input 1" visible="1" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   <PIN pinname="Source Maximum">
+   </PIN>
+   <PIN pinname="Destination Maximum">
+   </PIN>
+   <PIN pinname="Mapping">
+   </PIN>
+   </NODE>
+   <LINK dstnodeid="6" dstpinname="Input 1" srcnodeid="8" srcpinname="Output">
+   </LINK>
+   <LINK srcnodeid="16" srcpinname="Whole Part" dstnodeid="8" dstpinname="Input 1">
+   </LINK>
+   <NODE id="15" nodename="Mod (Value)" systemname="Mod (Value)">
+   <BOUNDS height="0" left="2835" top="1980" type="Node" width="0">
+   </BOUNDS>
+   <PIN pinname="Input 2" slicecount="1" values="120">
+   </PIN>
+   <PIN pinname="Input 1" visible="1" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   <PIN pinname="Source Maximum">
+   </PIN>
+   <PIN pinname="Destination Maximum">
+   </PIN>
+   <PIN pinname="Mapping">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="15" srcpinname="Output" dstnodeid="9" dstpinname="Data1">
+   </LINK>
+   <LINK srcnodeid="17" srcpinname="Whole Part" dstnodeid="15" dstpinname="Input 1">
+   </LINK>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="18" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="5250" top="3690" width="3315" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="5250" top="3690" width="4260" height="750">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="|Controller number only allowed from 0 to 119, 120-127 are reserved.&cr;&lf;see: http://www.midi.org/techspecs/midimessages.php|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   </NODE>
    </PATCH>

--- a/vvvv45/lib/nodes/modules/Devices/MidiNoteOut (Devices Bang).v4p
+++ b/vvvv45/lib/nodes/modules/Devices/MidiNoteOut (Devices Bang).v4p
@@ -1,9 +1,9 @@
-<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45debug29.1.dtd" >
-   <PATCH nodename="C:\Dev\vvvv\vvvv\public\vvvv45\lib\nodes\modules\Devices\MidiNoteOut (Devices Bang).v4p" systemname="MidiNoteOut (Devices Bang)" filename="C:\Dev\vvvv\vvvv\public\vvvv45\lib\nodes\modules\Devices\MidiNoteOut (Devices Bang).v4p">
-   <BOUNDS height="11415" left="7695" top="6135" type="Window" width="11805">
+<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45alpha29.3.dtd" >
+   <PATCH nodename="C:\vvvv\git\vvvv-sdk\vvvv45\lib\nodes\modules\Devices\MidiNoteOut (Devices Bang).v4p" systemname="MidiNoteOut (Devices Bang)" filename="C:\Dev\vvvv\vvvv\public\vvvv45\lib\nodes\modules\Devices\MidiNoteOut (Devices Bang).v4p">
+   <BOUNDS height="6165" left="8520" top="4410" type="Window" width="9000">
    </BOUNDS>
    <NODE id="13" nodename="MidiShortOutput (Devices)" systemname="MidiShortOutput (Devices)">
-   <BOUNDS height="0" left="2400" top="3765" type="Node" width="0">
+   <BOUNDS height="270" left="2250" top="3765" type="Node" width="2925">
    </BOUNDS>
    <PIN pinname="Do Send" visible="1">
    </PIN>
@@ -11,9 +11,9 @@
    </PIN>
    <PIN pinname="Midi Output Port" visible="1">
    </PIN>
-   <PIN pinname="Data1" visible="1">
+   <PIN pinname="Data1" visible="1" slicecount="1" values="0.5">
    </PIN>
-   <PIN pinname="Data2" visible="1">
+   <PIN pinname="Data2" visible="1" slicecount="1" values="99.06">
    </PIN>
    <PIN pinname="Enabled" visible="1">
    </PIN>
@@ -50,42 +50,12 @@
    </NODE>
    <LINK dstnodeid="13" dstpinname="Do Send" srcnodeid="12" srcpinname="Y Output Value">
    </LINK>
-   <NODE id="11" nodename="Mod (Value)" systemname="Mod (Value)">
-   <BOUNDS height="0" left="2220" top="1965" type="Node" width="0">
-   </BOUNDS>
-   <PIN pinname="Input 2" slicecount="1" values="16">
-   </PIN>
-   <PIN pinname="Input 1" visible="1">
-   </PIN>
-   <PIN pinname="Output" visible="1">
-   </PIN>
-   </NODE>
-   <NODE componentmode="InABox" id="10" nodename="IOBox (Value Advanced)" systemname="IOBox (Value Advanced)">
-   <BOUNDS height="0" left="1305" top="255" type="Node" width="0">
-   </BOUNDS>
-   <BOUNDS height="160" left="9900" top="4620" type="Window" width="215">
-   </BOUNDS>
-   <BOUNDS height="240" left="1305" top="255" type="Box" width="795">
-   </BOUNDS>
-   <PIN pinname="Y Output Value" visible="1">
-   </PIN>
-   <PIN pinname="Y Input Value" slicecount="1" values="1">
-   </PIN>
-   <PIN pinname="Descriptive Name" slicecount="1" values="Channel">
-   </PIN>
-   <PIN pinname="Minimum" slicecount="1" values="1">
-   </PIN>
-   <PIN pinname="Maximum" slicecount="1" values="16">
-   </PIN>
-   <PIN pinname="Value Type" slicecount="1" values="Integer">
-   </PIN>
-   </NODE>
    <NODE id="9" nodename="Add (Value)" systemname="Add (Value)">
    <BOUNDS height="0" left="2250" top="2595" type="Node" width="0">
    </BOUNDS>
    <PIN pinname="Input 2" slicecount="1" visible="1" values="144">
    </PIN>
-   <PIN pinname="Input 1" visible="1">
+   <PIN pinname="Input 1" visible="1" slicecount="1" values="0.5">
    </PIN>
    <PIN pinname="Output" visible="1">
    </PIN>
@@ -101,11 +71,15 @@
    </BOUNDS>
    <PIN pinname="Y Output Value" visible="1">
    </PIN>
-   <PIN pinname="Y Input Value" slicecount="1" values="7">
+   <PIN pinname="Y Input Value" slicecount="1" values="39">
    </PIN>
    <PIN pinname="Descriptive Name" slicecount="1" values="Note">
    </PIN>
    <PIN pinname="Value Type" slicecount="1" values="Integer">
+   </PIN>
+   <PIN pinname="Minimum" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Maximum" slicecount="1" values="127">
    </PIN>
    </NODE>
    <NODE componentmode="InABox" id="7" nodename="IOBox (Value Advanced)" systemname="IOBox (Value Advanced)">
@@ -119,35 +93,17 @@
    </PIN>
    <PIN pinname="Descriptive Name" slicecount="1" values="Velocity">
    </PIN>
-   <PIN pinname="Y Input Value" slicecount="10" values="0,0,0,0,0,0,0,0,0,0">
+   <PIN pinname="Y Input Value" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="X Input Value" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Minimum" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Maximum" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="Default" slicecount="1" values="1">
    </PIN>
    </NODE>
-   <LINK dstnodeid="9" dstpinname="Input 1" srcnodeid="11" srcpinname="Output">
-   </LINK>
-   <NODE id="5" nodename="Mod (Value)" systemname="Mod (Value)">
-   <BOUNDS height="0" left="3255" top="1305" type="Node" width="0">
-   </BOUNDS>
-   <PIN pinname="Input 2" slicecount="1" values="128">
-   </PIN>
-   <PIN pinname="Input 1" visible="1">
-   </PIN>
-   <PIN pinname="Output" visible="1">
-   </PIN>
-   </NODE>
-   <LINK dstnodeid="13" dstpinname="Data1" srcnodeid="5" srcpinname="Output">
-   </LINK>
-   <NODE id="4" nodename="Mod (Value)" systemname="Mod (Value)">
-   <BOUNDS height="0" left="4095" top="1500" type="Node" width="0">
-   </BOUNDS>
-   <PIN pinname="Input 2" slicecount="1" values="128">
-   </PIN>
-   <PIN pinname="Input 1" visible="1">
-   </PIN>
-   <PIN pinname="Output" visible="1">
-   </PIN>
-   </NODE>
-   <LINK dstnodeid="13" dstpinname="Data2" srcnodeid="4" srcpinname="Output">
-   </LINK>
    <NODE componentmode="InABox" id="3" nodename="IOBox (Value Advanced)" systemname="IOBox (Value Advanced)">
    <BOUNDS height="0" left="5115" top="330" type="Node" width="0">
    </BOUNDS>
@@ -165,11 +121,11 @@
    </PIN>
    </NODE>
    <NODE componentmode="InABox" id="2" nodename="IOBox (Enumerations)" systemname="IOBox (Enumerations)">
-   <BOUNDS height="0" left="8640" top="420" type="Node" width="0">
+   <BOUNDS height="0" left="7290" top="420" type="Node" width="0">
    </BOUNDS>
    <BOUNDS height="160" left="18345" top="5415" type="Window" width="215">
    </BOUNDS>
-   <BOUNDS height="240" left="8640" top="420" type="Box" width="795">
+   <BOUNDS height="240" left="7290" top="420" type="Box" width="795">
    </BOUNDS>
    <PIN pinname="Output Enum" visible="1">
    </PIN>
@@ -192,10 +148,6 @@
    </NODE>
    <LINK dstnodeid="1" dstpinname="Input 1" srcnodeid="7" srcpinname="Y Output Value">
    </LINK>
-   <LINK dstnodeid="4" dstpinname="Input 1" srcnodeid="1" srcpinname="Output">
-   </LINK>
-   <LINK dstnodeid="5" dstpinname="Input 1" srcnodeid="8" srcpinname="Y Output Value">
-   </LINK>
    <LINK dstnodeid="13" dstpinname="Enabled" srcnodeid="3" srcpinname="Y Output Value">
    </LINK>
    <NODE componentmode="InABox" id="0" nodename="IOBox (String)" systemname="IOBox (String)">
@@ -214,6 +166,88 @@
    </NODE>
    <INFO author="vvvv group" description="Plays out notes via MIDI." tags="io">
    </INFO>
-   <LINK srcnodeid="10" srcpinname="Y Output Value" dstnodeid="11" dstpinname="Input 1">
+   <NODE id="5" nodename="Mod (Value)" systemname="Mod (Value)">
+   <PIN pinname="Input 1" visible="1">
+   </PIN>
+   <BOUNDS type="Node" height="0" left="3405" top="1515" width="0">
+   </BOUNDS>
+   <PIN pinname="Input 2" slicecount="1" values="128">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="8" srcpinname="Y Output Value" dstnodeid="5" dstpinname="Input 1">
+   </LINK>
+   <LINK srcnodeid="5" srcpinname="Output" dstnodeid="13" dstpinname="Data1">
+   </LINK>
+   <NODE id="4" nodename="Mod (Value)" systemname="Mod (Value)">
+   <PIN pinname="Input 1" visible="1">
+   </PIN>
+   <BOUNDS type="Node" height="0" left="4095" top="1500" width="0">
+   </BOUNDS>
+   <PIN pinname="Input 2" slicecount="1" values="128">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="1" srcpinname="Output" dstnodeid="4" dstpinname="Input 1">
+   </LINK>
+   <LINK srcnodeid="4" srcpinname="Output" dstnodeid="13" dstpinname="Data2">
+   </LINK>
+   <NODE systemname="Frac (Value)" nodename="Frac (Value)" componentmode="Hidden" id="15">
+   <BOUNDS type="Node" left="2235" top="1425" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Whole Part" visible="1">
+   </PIN>
+   <PIN pinname="Input" visible="1" slicecount="1" values="15">
+   </PIN>
+   </NODE>
+   <NODE id="14" nodename="Mod (Value)" systemname="Mod (Value)" hiddenwhenlocked="0" managers="">
+   <PIN pinname="Input" visible="1" pintype="Input">
+   </PIN>
+   <PIN pinname="Output" visible="1" pintype="Output">
+   </PIN>
+   <BOUNDS type="Node" height="0" left="2250" top="2025" width="0">
+   </BOUNDS>
+   <PIN pinname="Mapping" pintype="Input" visible="1">
+   </PIN>
+   <PIN pinname="Source Maximum" pintype="Input" visible="1">
+   </PIN>
+   <PIN pinname="Destination Maximum" pintype="Input" visible="1">
+   </PIN>
+   <PIN pinname="Descriptive Name" pintype="Configuration" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Source Minimum" pintype="Input" visible="1">
+   </PIN>
+   <PIN pinname="Destination Minimum" pintype="Input" visible="1">
+   </PIN>
+   <PIN pinname="ID" pintype="Output" visible="-1">
+   </PIN>
+   <PIN pinname="Input 2" slicecount="1" values="16">
+   </PIN>
+   <PIN pinname="Input 1" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="14" srcpinname="Output" dstnodeid="9" dstpinname="Input 1">
+   </LINK>
+   <LINK srcnodeid="15" srcpinname="Whole Part" dstnodeid="14" dstpinname="Input 1">
+   </LINK>
+   <NODE componentmode="InABox" id="16" nodename="IOBox (Value Advanced)" systemname="IOBox (Value Advanced)">
+   <BOUNDS height="0" left="1350" top="255" type="Node" width="0">
+   </BOUNDS>
+   <BOUNDS height="160" left="9900" top="4620" type="Window" width="215">
+   </BOUNDS>
+   <BOUNDS height="240" left="1350" top="255" type="Box" width="795">
+   </BOUNDS>
+   <PIN pinname="Value Type" slicecount="1" values="Integer">
+   </PIN>
+   <PIN pinname="Minimum" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Maximum" slicecount="1" values="15">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Input">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="16" srcpinname="Y Output Value" dstnodeid="15" dstpinname="Input">
    </LINK>
    </PATCH>

--- a/vvvv45/lib/nodes/modules/Devices/MidiNoteOut (Devices).v4p
+++ b/vvvv45/lib/nodes/modules/Devices/MidiNoteOut (Devices).v4p
@@ -1,6 +1,6 @@
-<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45debug29.1.dtd" >
-   <PATCH nodename="C:\Dev\vvvv\vvvv\public\vvvv45\lib\nodes\modules\MidiNoteOut (Devices).v4p">
-   <BOUNDS height="6000" left="10470" top="9240" type="Window" width="9000">
+<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45alpha29.3.dtd" >
+   <PATCH nodename="C:\vvvv\git\vvvv-sdk\vvvv45\lib\nodes\modules\Devices\MidiNoteOut (Devices).v4p">
+   <BOUNDS height="8775" left="7935" top="2235" type="Window" width="10725">
    </BOUNDS>
    <NODE id="16" nodename="MidiShortOutput (Devices)" systemname="MidiShortOutput (Devices)">
    <BOUNDS height="0" left="3045" top="7245" type="Node" width="0">
@@ -33,35 +33,23 @@
    </PIN>
    <PIN pinname="Value Type" slicecount="1" values="Integer">
    </PIN>
+   <PIN pinname="X Input Value" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Minimum" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Maximum" slicecount="1" values="15">
+   </PIN>
    </NODE>
    <NODE id="14" nodename="Add (Value)" systemname="Add (Value)">
    <BOUNDS height="0" left="2670" top="5265" type="Node" width="0">
    </BOUNDS>
-   <PIN pinname="Input 1" visible="1">
+   <PIN pinname="Input 1" visible="1" slicecount="1" values="0">
    </PIN>
    <PIN pinname="Input 2" slicecount="1" values="144">
    </PIN>
    <PIN pinname="Output" visible="1">
    </PIN>
    </NODE>
-   <NODE id="13" nodename="Map (Value)" systemname="Map (Value)">
-   <BOUNDS height="0" left="2685" top="4875" type="Node" width="0">
-   </BOUNDS>
-   <PIN pinname="Mapping" slicecount="1" values="Wrap">
-   </PIN>
-   <PIN pinname="Source Maximum" slicecount="1" values="15">
-   </PIN>
-   <PIN pinname="Input" visible="1">
-   </PIN>
-   <PIN pinname="Destination Maximum" slicecount="1" values="15">
-   </PIN>
-   <PIN pinname="Output" visible="1">
-   </PIN>
-   </NODE>
-   <LINK dstnodeid="13" dstpinname="Input" srcnodeid="15" srcpinname="Y Output Value">
-   </LINK>
-   <LINK dstnodeid="14" dstpinname="Input 1" srcnodeid="13" srcpinname="Output">
-   </LINK>
    <LINK dstnodeid="16" dstpinname="Message" srcnodeid="14" srcpinname="Output">
    </LINK>
    <NODE componentmode="InABox" id="12" nodename="IOBox (Value Advanced)" systemname="IOBOX (VALUE ADVANCED)">
@@ -75,7 +63,7 @@
    </PIN>
    <PIN pinname="Y Output Value" visible="1">
    </PIN>
-   <PIN pinname="Y Input Value" slicecount="1" visible="1" values="62,63,64,65,66,67,68">
+   <PIN pinname="Y Input Value" slicecount="1" visible="1" values="62">
    </PIN>
    <PIN pinname="Value Type" slicecount="1" values="Integer">
    </PIN>
@@ -119,7 +107,7 @@
    </PIN>
    <PIN pinname="Y Output Value" visible="1">
    </PIN>
-   <PIN pinname="Y Input Value" slicecount="1" visible="1" values="0,0,1,0,0,0,0">
+   <PIN pinname="Y Input Value" slicecount="1" visible="1" values="0">
    </PIN>
    <PIN pinname="Value Type" slicecount="1" values="Boolean">
    </PIN>
@@ -143,7 +131,7 @@
    <LINK dstnodeid="11" dstpinname="Input 2" srcnodeid="8" srcpinname="Output">
    </LINK>
    <NODE componentmode="InABox" hiddenwhenlocked="0" id="7" managers="" nodename="IOBox (Value Advanced)" systemname="IOBOX (VALUE ADVANCED)">
-   <PIN pinname="Y Input Value" pintype="Input" slicecount="1" visible="0" values="0">
+   <PIN pinname="Y Input Value" pintype="Input" slicecount="1" visible="0" values="1">
    </PIN>
    <PIN pinname="Y Output Value" pintype="Output" visible="1">
    </PIN>
@@ -183,9 +171,9 @@
    </PIN>
    <PIN pinname="Allow MouseOffset" pintype="Configuration" slicecount="1" values="1">
    </PIN>
-   <PIN pinname="Minimum" pintype="Configuration" slicecount="1" values="-1000">
+   <PIN pinname="Minimum" pintype="Configuration" slicecount="1" values="0">
    </PIN>
-   <PIN pinname="Maximum" pintype="Configuration" slicecount="1" values="1000">
+   <PIN pinname="Maximum" pintype="Configuration" slicecount="1" values="1">
    </PIN>
    <PIN pinname="Slider Alignment" pintype="Configuration" slicecount="1" values="Grid">
    </PIN>
@@ -195,9 +183,11 @@
    </PIN>
    <PIN pinname="SliceOffset" pintype="Input" slicecount="1" visible="0" values="0">
    </PIN>
-   <PIN pinname="X Input Value" pintype="Input" slicecount="1" visible="0" values="0">
+   <PIN pinname="X Input Value" pintype="Input" slicecount="1" visible="0" values="1">
    </PIN>
    <PIN pinname="X Output Value" pintype="Output" visible="0">
+   </PIN>
+   <PIN pinname="Default" slicecount="1" values="1">
    </PIN>
    </NODE>
    <LINK dstnodeid="8" dstpinname="Input" srcnodeid="7" srcpinname="Y Output Value">
@@ -283,7 +273,7 @@
    <LINK dstnodeid="10" dstpinname="Input" srcnodeid="1" srcpinname="Output">
    </LINK>
    <NODE id="0" nodename="Resample (Spreads)" systemname="Resample (Spreads)">
-   <BOUNDS height="0" left="2970" top="3915" type="Node" width="0">
+   <BOUNDS height="0" left="3450" top="3720" type="Node" width="0">
    </BOUNDS>
    <PIN pinname="Spread Count" visible="1">
    </PIN>
@@ -301,11 +291,11 @@
    <INFO author="tonfilm" description="module to send midi notes" tags="midi, hardware">
    </INFO>
    <NODE componentmode="InABox" id="17" nodename="IOBox (Enumerations)" systemname="IOBox (Enumerations)">
-   <BOUNDS height="0" left="7155" top="780" type="Node" width="0">
+   <BOUNDS height="0" left="8370" top="600" type="Node" width="0">
    </BOUNDS>
    <BOUNDS height="160" left="18345" top="5415" type="Window" width="215">
    </BOUNDS>
-   <BOUNDS height="240" left="7155" top="780" type="Box" width="795">
+   <BOUNDS height="240" left="8370" top="600" type="Box" width="795">
    </BOUNDS>
    <PIN pinname="Output Enum" visible="1">
    </PIN>
@@ -315,5 +305,57 @@
    </PIN>
    </NODE>
    <LINK srcnodeid="17" srcpinname="Output Enum" dstnodeid="16" dstpinname="Midi Output Port">
+   </LINK>
+   <NODE systemname="Frac (Value)" nodename="Frac (Value)" componentmode="Hidden" id="18">
+   <BOUNDS type="Node" left="2595" top="2400" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   <PIN pinname="Whole Part" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="15" srcpinname="Y Output Value" dstnodeid="18" dstpinname="Input">
+   </LINK>
+   <NODE id="13" nodename="Mod (Value)" systemname="Mod (Value)">
+   <BOUNDS height="0" left="2685" top="4875" type="Node" width="0">
+   </BOUNDS>
+   <PIN pinname="Mapping">
+   </PIN>
+   <PIN pinname="Source Maximum">
+   </PIN>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   <PIN pinname="Destination Maximum">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <PIN pinname="Input 1" visible="1">
+   </PIN>
+   <PIN pinname="Input 2" slicecount="1" values="16">
+   </PIN>
+   </NODE>
+   <LINK dstnodeid="14" dstpinname="Input 1" srcnodeid="13" srcpinname="Output">
+   </LINK>
+   <LINK srcnodeid="18" srcpinname="Whole Part" dstnodeid="13" dstpinname="Input 1">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="19" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Node" left="6915" top="375" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="6915" top="375" width="480" height="480">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Boolean">
+   </PIN>
+   <PIN pinname="Behavior" slicecount="1" values="Toggle">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Enabled">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="19" srcpinname="Y Output Value" dstnodeid="16" dstpinname="Enabled">
    </LINK>
    </PATCH>

--- a/vvvv45/lib/nodes/modules/Devices/MidiProgramOut (Devices).v4p
+++ b/vvvv45/lib/nodes/modules/Devices/MidiProgramOut (Devices).v4p
@@ -1,9 +1,9 @@
-<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45debug29.1.dtd" >
-   <PATCH nodename="C:\Dev\vvvv\vvvv\public\vvvv45\lib\nodes\modules\Devices\MidiProgramOut (Devices).v4p" systemname="MidiProgramOut (Devices)" filename="C:\Dev\vvvv\vvvv\public\vvvv45\lib\nodes\modules\Devices\MidiProgramOut (Devices).v4p">
+<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45alpha29.3.dtd" >
+   <PATCH nodename="C:\vvvv\git\vvvv-sdk\vvvv45\lib\nodes\modules\Devices\MidiProgramOut (Devices).v4p" systemname="MidiProgramOut (Devices)" filename="C:\Dev\vvvv\vvvv\public\vvvv45\lib\nodes\modules\Devices\MidiProgramOut (Devices).v4p">
    <BOUNDS height="6000" left="6225" top="8985" type="Window" width="9000">
    </BOUNDS>
    <NODE id="5" nodename="MidiShortOutput (Devices)" systemname="MidiShortOutput (Devices)">
-   <BOUNDS height="0" left="4080" top="4485" type="Node" width="0">
+   <BOUNDS height="0" left="2280" top="4485" type="Node" width="0">
    </BOUNDS>
    <PIN pinname="Message" visible="1">
    </PIN>
@@ -17,11 +17,11 @@
    </PIN>
    </NODE>
    <NODE componentmode="InABox" id="4" nodename="IOBOX (VALUE ADVANCED)" systemname="IOBox (Value Advanced)">
-   <BOUNDS height="0" left="3975" top="705" type="Node" width="0">
+   <BOUNDS height="0" left="2505" top="705" type="Node" width="0">
    </BOUNDS>
    <BOUNDS height="160" left="3180" top="5490" type="Window" width="215">
    </BOUNDS>
-   <BOUNDS height="240" left="3975" top="705" type="Box" width="795">
+   <BOUNDS height="240" left="2505" top="705" type="Box" width="795">
    </BOUNDS>
    <PIN pinname="Descriptive Name" slicecount="1" values="Channel">
    </PIN>
@@ -31,53 +31,47 @@
    </PIN>
    <PIN pinname="Value Type" slicecount="1" values="Integer">
    </PIN>
+   <PIN pinname="Minimum" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Maximum" slicecount="1" values="15">
+   </PIN>
    </NODE>
    <NODE id="3" nodename="Add (Value)" systemname="Add (Value)">
-   <BOUNDS height="0" left="3840" top="3270" type="Node" width="0">
+   <BOUNDS height="0" left="2520" top="3135" type="Node" width="0">
    </BOUNDS>
-   <PIN pinname="Input 1" visible="1">
+   <PIN pinname="Input 1" visible="1" slicecount="1" values="0">
    </PIN>
    <PIN pinname="Input 2" slicecount="1" values="192">
    </PIN>
    <PIN pinname="Output" visible="1">
    </PIN>
    </NODE>
-   <NODE id="2" nodename="Map (Value)" systemname="Map (Value)">
-   <BOUNDS height="0" left="3780" top="2760" type="Node" width="0">
-   </BOUNDS>
-   <PIN pinname="Mapping" slicecount="1" values="Wrap">
-   </PIN>
-   <PIN pinname="Source Maximum" slicecount="1" values="15">
-   </PIN>
-   <PIN pinname="Input" visible="1">
-   </PIN>
-   <PIN pinname="Destination Maximum" slicecount="1" values="15">
-   </PIN>
-   <PIN pinname="Output" visible="1">
-   </PIN>
-   </NODE>
-   <LINK dstnodeid="2" dstpinname="Input" srcnodeid="4" srcpinname="Y Output Value">
-   </LINK>
-   <LINK dstnodeid="3" dstpinname="Input 1" srcnodeid="2" srcpinname="Output">
-   </LINK>
    <LINK dstnodeid="5" dstpinname="Message" srcnodeid="3" srcpinname="Output">
    </LINK>
    <NODE componentmode="InABox" id="1" nodename="IOBOX (VALUE ADVANCED)" systemname="IOBox (Value Advanced)">
-   <BOUNDS height="0" left="5310" top="705" type="Node" width="0">
+   <BOUNDS height="0" left="4470" top="705" type="Node" width="0">
    </BOUNDS>
    <BOUNDS height="160" left="4485" top="5280" type="Window" width="215">
    </BOUNDS>
-   <BOUNDS height="240" left="5310" top="705" type="Box" width="795">
+   <BOUNDS height="240" left="4470" top="705" type="Box" width="795">
    </BOUNDS>
    <PIN pinname="Descriptive Name" slicecount="1" values="Program">
    </PIN>
    <PIN pinname="Y Output Value" visible="1">
    </PIN>
-   <PIN pinname="Y Input Value" slicecount="7" visible="1" values="86,63,64,65,66,67,68">
+   <PIN pinname="Y Input Value" slicecount="1" visible="1" values="0">
+   </PIN>
+   <PIN pinname="Minimum" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Maximum" slicecount="1" values="127">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Integer">
+   </PIN>
+   <PIN pinname="X Input Value" slicecount="1" values="0">
    </PIN>
    </NODE>
    <NODE id="0" nodename="CHANGE (ANIMATION)" systemname="Change (Animation)">
-   <BOUNDS height="0" left="2910" top="3150" type="Node" width="0">
+   <BOUNDS height="0" left="1110" top="3150" type="Node" width="0">
    </BOUNDS>
    <PIN pinname="Input" visible="1">
    </PIN>
@@ -96,4 +90,68 @@
    </LINK>
    <INFO author="tonfilm" description="module to send midi programm change messages" tags="io">
    </INFO>
+   <NODE nodename="IOBox (Enumerations)" componentmode="InABox" id="6" systemname="IOBox (Enumerations)">
+   <BOUNDS type="Node" left="6975" top="735" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="6975" top="735" width="1590" height="240">
+   </BOUNDS>
+   <PIN pinname="Input Enum" slicecount="1" values="|Microsoft GS Wavetable Synth|">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="|Midi Output Port|">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="6" srcpinname="Output Enum" dstnodeid="5" dstpinname="Midi Output Port">
+   </LINK>
+   <NODE systemname="Frac (Value)" nodename="Frac (Value)" componentmode="Hidden" id="7">
+   <BOUNDS type="Node" left="2505" top="1425" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   <PIN pinname="Whole Part" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="4" srcpinname="Y Output Value" dstnodeid="7" dstpinname="Input">
+   </LINK>
+   <NODE id="2" nodename="Mod (Value)" systemname="Mod (Value)">
+   <BOUNDS height="0" left="2520" top="2640" type="Node" width="0">
+   </BOUNDS>
+   <PIN pinname="Mapping">
+   </PIN>
+   <PIN pinname="Source Maximum">
+   </PIN>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   <PIN pinname="Destination Maximum">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <PIN pinname="Input 2" slicecount="1" values="16">
+   </PIN>
+   <PIN pinname="Input 1" visible="1">
+   </PIN>
+   </NODE>
+   <LINK dstnodeid="3" dstpinname="Input 1" srcnodeid="2" srcpinname="Output">
+   </LINK>
+   <LINK srcnodeid="7" srcpinname="Whole Part" dstnodeid="2" dstpinname="Input 1">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="8" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Node" left="5805" top="540" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="5805" top="540" width="480" height="480">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Boolean">
+   </PIN>
+   <PIN pinname="Behavior" slicecount="1" values="Toggle">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Enabled">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="8" srcpinname="Y Output Value" dstnodeid="5" dstpinname="Enabled">
+   </LINK>
    </PATCH>

--- a/vvvv45/lib/nodes/native/MidiBend (Devices) help.v4p
+++ b/vvvv45/lib/nodes/native/MidiBend (Devices) help.v4p
@@ -1,0 +1,143 @@
+<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45alpha29.3.dtd" >
+   <PATCH nodename="C:\vvvv\git\vvvv-sdk\vvvv45\lib\nodes\native\MidiBend (Devices) help.v4p">
+   <BOUNDS type="Window" left="4680" top="3360" width="9660" height="8040">
+   </BOUNDS>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="3" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="150" top="150" width="5000" height="450">
+   </BOUNDS>
+   <BOUNDS type="Box" left="150" top="150" width="5000" height="450">
+   </BOUNDS>
+   <PIN pinname="Input String" slicecount="1" visible="0" values="|MidiBend (Devices)|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Size" slicecount="1" visible="1" values="14">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="2" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="150" top="550" width="5000" height="500">
+   </BOUNDS>
+   <BOUNDS type="Box" left="150" top="550" width="5000" height="500">
+   </BOUNDS>
+   <PIN pinname="Input String" slicecount="1" visible="0" values="|Handles midi pitch bend commands|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   </NODE>
+   <NODE nodename="MidiBend (Devices)" componentmode="Hidden" id="0" systemname="MidiBend (Devices)">
+   <BOUNDS type="Node" left="2410" top="3680" width="2370" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="2410" top="3680" width="0" height="0">
+   </BOUNDS>
+   </NODE>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="4" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Node" left="2430" top="2835" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="2430" top="2835" width="795" height="240">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Integer">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Channel">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="4" srcpinname="Y Output Value" dstnodeid="0" dstpinname="Channel">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="5" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Node" left="3960" top="2280" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="3960" top="2280" width="480" height="480">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Boolean">
+   </PIN>
+   <PIN pinname="Behavior" slicecount="1" values="Toggle">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Enabled">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="5" srcpinname="Y Output Value" dstnodeid="0" dstpinname="Enabled">
+   </LINK>
+   <NODE nodename="IOBox (Enumerations)" componentmode="InABox" id="6" systemname="IOBox (Enumerations)">
+   <BOUNDS type="Node" left="4740" top="3030" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="4740" top="3030" width="1590" height="240">
+   </BOUNDS>
+   <PIN pinname="Input Enum" slicecount="1" values="|loopMIDI Port|">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="|Midi Input Port|">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="6" srcpinname="Output Enum" dstnodeid="0" dstpinname="Midi Input Port">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="7" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Node" left="2430" top="4275" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="2430" top="4275" width="795" height="240">
+   </BOUNDS>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Output">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="0" srcpinname="Output" dstnodeid="7" dstpinname="Y Input Value">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="8" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Node" left="3585" top="4275" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="3585" top="4275" width="480" height="480">
+   </BOUNDS>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Boolean">
+   </PIN>
+   <PIN pinname="Behavior" slicecount="1" values="Bang">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="|On Data|">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="0" srcpinname="On Data" dstnodeid="8" dstpinname="Y Input Value">
+   </LINK>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="9" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="2100" top="1470" width="7230" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="2100" top="1470" width="4800" height="315">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="|MidiBend outputs the pitch wheel values on the specified channels.|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="10" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="2310" top="5595" width="11805" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="2310" top="5595" width="4815" height="990">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="|Note: Unlike most of the other MIDI commands the pitch bend command transmits data with 14 bits (instead of the usual 7 bits, e.g. with control change messages). Therefore the available resolution is higher.|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   </NODE>
+   </PATCH>

--- a/vvvv45/lib/nodes/native/MidiController (Devices) help.v4p
+++ b/vvvv45/lib/nodes/native/MidiController (Devices) help.v4p
@@ -1,0 +1,515 @@
+<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45alpha29.3.dtd" >
+   <PATCH nodename="C:\vvvv\git\vvvv-sdk\vvvv45\lib\nodes\native\MidiController (Devices) help.v4p">
+   <BOUNDS type="Window" left="4740" top="915" width="15360" height="13350">
+   </BOUNDS>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="3" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="150" top="150" width="5000" height="450">
+   </BOUNDS>
+   <BOUNDS type="Box" left="150" top="150" width="5000" height="450">
+   </BOUNDS>
+   <PIN pinname="Input String" slicecount="1" visible="0" values="|MidiController (Devices)|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Size" slicecount="1" visible="1" values="14">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="2" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="150" top="550" width="5000" height="500">
+   </BOUNDS>
+   <BOUNDS type="Box" left="150" top="550" width="5000" height="500">
+   </BOUNDS>
+   <PIN pinname="Input String" slicecount="1" visible="0" values="|Handles MIDI ControlChange (CC) commands|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   </NODE>
+   <NODE nodename="MidiController (Devices)" componentmode="Hidden" id="0" systemname="MidiController (Devices)">
+   <BOUNDS type="Node" left="995" top="4555" width="2640" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="995" top="4555" width="0" height="0">
+   </BOUNDS>
+   </NODE>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="4" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Node" left="540" top="3645" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="540" top="3645" width="795" height="240">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Integer">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Channel">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="4" srcpinname="Y Output Value" dstnodeid="0" dstpinname="Channel">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="5" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Node" left="1635" top="2985" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="1635" top="2985" width="750" height="870">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="3" values="1,2,5">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Integer">
+   </PIN>
+   <PIN pinname="SliceCount Mode" slicecount="1" values="ColsRowsPages">
+   </PIN>
+   <PIN pinname="Rows" slicecount="1" values="3">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Controller">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="5" srcpinname="Y Output Value" dstnodeid="0" dstpinname="Controller">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="6" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Node" left="2910" top="3375" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="2910" top="3375" width="480" height="480">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Boolean">
+   </PIN>
+   <PIN pinname="Behavior" slicecount="1" values="Toggle">
+   </PIN>
+   <PIN pinname="X Input Value" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Enabled">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="6" srcpinname="Y Output Value" dstnodeid="0" dstpinname="Enabled">
+   </LINK>
+   <NODE nodename="IOBox (Enumerations)" componentmode="InABox" id="7" systemname="IOBox (Enumerations)">
+   <BOUNDS type="Node" left="3570" top="3945" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="3570" top="3945" width="1590" height="240">
+   </BOUNDS>
+   <PIN pinname="Input Enum" slicecount="1" values="|loopMIDI Port|">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="|Midi Input Port|">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="7" srcpinname="Output Enum" dstnodeid="0" dstpinname="Midi Input Port">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="8" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Node" left="975" top="5685" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="975" top="5685" width="750" height="795">
+   </BOUNDS>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Rows" slicecount="1" values="3">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Output">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="0" srcpinname="Output" dstnodeid="8" dstpinname="Y Input Value">
+   </LINK>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="9" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="3390" top="3390" width="1200" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="3390" top="3390" width="1200" height="270">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="|Enable me first|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="10" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Node" left="2295" top="5295" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="2295" top="5295" width="510" height="1170">
+   </BOUNDS>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Boolean">
+   </PIN>
+   <PIN pinname="Behavior" slicecount="1" values="Bang">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="|On Data|">
+   </PIN>
+   <PIN pinname="Rows" slicecount="1" values="3">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="0" srcpinname="On Data" dstnodeid="10" dstpinname="Y Input Value">
+   </LINK>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="11" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="435" top="1260" width="7230" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="435" top="1260" width="3915" height="1365">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="|MidiController outputs the controller values of the specified controller IDs on the channel specified.&cr;&lf;&cr;&lf;You have to specify all the controllers of interest. Only the values of corresponding controllers will be output.|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="17" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="405" top="8415" width="705" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="405" top="8415" width="705" height="270">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="|also see|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   </NODE>
+   <NODE systemname="MidiShort (Devices)" nodename="MidiShort (Devices)" componentmode="Hidden" id="16">
+   <BOUNDS type="Node" left="1215" top="8400" width="100" height="100">
+   </BOUNDS>
+   </NODE>
+   <NODE systemname="MidiBend (Devices)" nodename="MidiBend (Devices)" componentmode="Hidden" id="14">
+   <BOUNDS type="Node" left="2190" top="8820" width="100" height="100">
+   </BOUNDS>
+   </NODE>
+   <NODE systemname="MidiSysex (Devices)" nodename="MidiSysex (Devices)" componentmode="Hidden" id="13">
+   <BOUNDS type="Node" left="1215" top="8820" width="100" height="100">
+   </BOUNDS>
+   </NODE>
+   <NODE systemname="MidiProgram (Devices)" nodename="MidiProgram (Devices)" componentmode="Hidden" id="12">
+   <BOUNDS type="Node" left="3300" top="8400" width="100" height="100">
+   </BOUNDS>
+   </NODE>
+   <NODE systemname="MidiShort (Devices)" nodename="MidiShort (Devices)" componentmode="Hidden" id="18">
+   <BOUNDS type="Node" left="6765" top="8610" width="3315" height="270">
+   </BOUNDS>
+   <PIN pinname="Message" visible="1">
+   </PIN>
+   </NODE>
+   <NODE componentmode="Hidden" id="20" nodename="SpellValue (String)" systemname="SpellValue (String)">
+   <BOUNDS height="0" left="6765" top="10500" type="Node" width="0">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Mode" slicecount="1" values="Hex">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   </NODE>
+   <NODE componentmode="InABox" id="19" nodename="IOBox (String)" systemname="IOBox (String)">
+   <BOUNDS height="0" left="6765" top="10905" type="Node" width="0">
+   </BOUNDS>
+   <BOUNDS height="240" left="6765" top="10905" type="Box" width="795">
+   </BOUNDS>
+   <BOUNDS height="160" left="20205" top="7545" type="Window" width="215">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="1">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="|Message Hex|">
+   </PIN>
+   </NODE>
+   <LINK dstnodeid="19" dstpinname="Input String" srcnodeid="20" srcpinname="Output">
+   </LINK>
+   <LINK srcnodeid="18" srcpinname="Message" dstnodeid="20" dstpinname="Input">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="21" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Node" left="7425" top="9795" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="7425" top="9795" width="795" height="240">
+   </BOUNDS>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Integer">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="|Data 1|">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="18" srcpinname="Data 1" dstnodeid="21" dstpinname="Y Input Value">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="22" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Node" left="8085" top="9105" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="8085" top="9105" width="795" height="240">
+   </BOUNDS>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Integer">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="|Data 2|">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="18" srcpinname="Data 2" dstnodeid="22" dstpinname="Y Input Value">
+   </LINK>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="23" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="6765" top="7050" width="7785" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="6765" top="7050" width="4695" height="600">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="|If you are not sure which controller ID your CC sending device has, you can use MidiShort to find the channel and ID.|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (Enumerations)" componentmode="InABox" id="24" systemname="IOBox (Enumerations)">
+   <BOUNDS type="Node" left="10020" top="7830" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="10020" top="7830" width="1590" height="240">
+   </BOUNDS>
+   <PIN pinname="Input Enum" slicecount="1" values="|loopMIDI Port|">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="|Midi Input Port|">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="24" srcpinname="Output Enum" dstnodeid="18" dstpinname="Midi Input Port">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="25" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Node" left="8940" top="7785" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="8940" top="7785" width="480" height="480">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Boolean">
+   </PIN>
+   <PIN pinname="Behavior" slicecount="1" values="Toggle">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Enabled">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="25" srcpinname="Y Output Value" dstnodeid="18" dstpinname="Enabled">
+   </LINK>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="26" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="7575" top="10485" width="7275" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="7575" top="10485" width="4935" height="1785">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="|Encoded in the message is the type of command and the MIDI channel on which the command is sent:&cr;&lf;In Hex notation the first digit specifies the type of command, the second digit specifies the channel:&cr;&lf;&cr;&lf;E.g.: B3 means: &cr;&lf;Command: B = Control Change&cr;&lf;Channel   : 3  |">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="27" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="8250" top="9795" width="4020" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="8250" top="9795" width="4020" height="270">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="|Data byte 1 holds the controller ID of the CC command|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="28" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="8880" top="9105" width="4440" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="8880" top="9105" width="4440" height="270">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="|Data byte 2 holds the value for the corresponding controller|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="38" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Node" left="7305" top="4830" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="7305" top="4830" width="795" height="240">
+   </BOUNDS>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Y Input Value" slicecount="120" values="0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0">
+   </PIN>
+   </NODE>
+   <NODE systemname="I (Spreads)" nodename="I (Spreads)" componentmode="Hidden" id="37">
+   <BOUNDS type="Node" left="7995" top="2760" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname=".. To [">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="36" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Node" left="7305" top="3405" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="7305" top="3405" width="795" height="240">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Integer">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Channel">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="35" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="7320" top="1500" width="5115" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="7320" top="1500" width="5640" height="615">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="|I (Spreads) comes in handy when you want to listen to a range of controllers. Valid Controller values are 0 to 119.|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="34" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Node" left="7485" top="2220" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="7485" top="2220" width="705" height="240">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Integer">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="|[ From ..|">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="34" srcpinname="Y Output Value" dstnodeid="37" dstpinname="[ From ..">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="33" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Node" left="8385" top="2220" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="8385" top="2220" width="795" height="240">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" values="120">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Integer">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="|.. To [|">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="33" srcpinname="Y Output Value" dstnodeid="37" dstpinname=".. To [">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="32" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Node" left="9405" top="3195" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="9405" top="3195" width="480" height="480">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Boolean">
+   </PIN>
+   <PIN pinname="Behavior" slicecount="1" values="Toggle">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Enabled">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (Enumerations)" componentmode="InABox" id="31" systemname="IOBox (Enumerations)">
+   <BOUNDS type="Node" left="10080" top="3525" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="10080" top="3525" width="1590" height="240">
+   </BOUNDS>
+   <PIN pinname="Input Enum" slicecount="1" values="|loopMIDI Port|">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="|Midi Input Port|">
+   </PIN>
+   </NODE>
+   <NODE systemname="Count (Value)" nodename="Count (Value)" componentmode="Hidden" id="30" hiddenwhenlocked="1">
+   <BOUNDS type="Node" left="8340" top="4770" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1" slicecount="120" values="0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="29" systemname="IOBox (Value Advanced)" hiddenwhenlocked="1">
+   <BOUNDS type="Node" left="8355" top="5160" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="8355" top="5160" width="795" height="240">
+   </BOUNDS>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Integer">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="30" srcpinname="Count" dstnodeid="29" dstpinname="Y Input Value">
+   </LINK>
+   <NODE systemname="MidiNote (Devices)" nodename="MidiNote (Devices)" componentmode="Hidden" id="15">
+   <BOUNDS type="Node" left="2325" top="8400" width="100" height="100">
+   </BOUNDS>
+   </NODE>
+   <NODE nodename="MidiController (Devices)" componentmode="Hidden" id="39" systemname="MidiController (Devices)">
+   <BOUNDS type="Node" left="7315" top="4130" width="2850" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="7315" top="4130" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <PIN pinname="Note" visible="1">
+   </PIN>
+   <PIN pinname="Controller" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="39" srcpinname="Output" dstnodeid="38" dstpinname="Y Input Value">
+   </LINK>
+   <LINK srcnodeid="36" srcpinname="Y Output Value" dstnodeid="39" dstpinname="Channel">
+   </LINK>
+   <LINK srcnodeid="32" srcpinname="Y Output Value" dstnodeid="39" dstpinname="Enabled">
+   </LINK>
+   <LINK srcnodeid="31" srcpinname="Output Enum" dstnodeid="39" dstpinname="Midi Input Port">
+   </LINK>
+   <LINK srcnodeid="39" srcpinname="Output" dstnodeid="30" dstpinname="Input">
+   </LINK>
+   <LINK srcnodeid="37" srcpinname="Output" dstnodeid="39" dstpinname="Controller">
+   </LINK>
+   </PATCH>

--- a/vvvv45/lib/nodes/native/MidiNote (Devices) help.v4p
+++ b/vvvv45/lib/nodes/native/MidiNote (Devices) help.v4p
@@ -1,0 +1,545 @@
+<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45alpha29.3.dtd" >
+   <PATCH nodename="C:\vvvv\git\vvvv-sdk\vvvv45\lib\nodes\native\MidiNote (Devices) help.v4p">
+   <BOUNDS type="Window" left="1290" top="570" width="14985" height="12720">
+   </BOUNDS>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="3" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="150" top="150" width="5000" height="450">
+   </BOUNDS>
+   <BOUNDS type="Box" left="150" top="150" width="5000" height="450">
+   </BOUNDS>
+   <PIN pinname="Input String" slicecount="1" visible="0" values="|MidiNote (Devices)|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Size" slicecount="1" visible="1" values="14">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="2" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="150" top="550" width="5000" height="500">
+   </BOUNDS>
+   <BOUNDS type="Box" left="150" top="550" width="5000" height="500">
+   </BOUNDS>
+   <PIN pinname="Input String" slicecount="1" visible="0" values="|Handles MIDI NoteOn/NoteOff commands|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   </NODE>
+   <NODE nodename="MidiNote (Devices)" componentmode="Hidden" id="0" systemname="MidiNote (Devices)">
+   <BOUNDS type="Node" left="625" top="4070" width="2850" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="625" top="4070" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="4" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Node" left="2700" top="2760" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="2700" top="2760" width="480" height="480">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Boolean">
+   </PIN>
+   <PIN pinname="Behavior" slicecount="1" values="Toggle">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Enabled">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="4" srcpinname="Y Output Value" dstnodeid="0" dstpinname="Enabled">
+   </LINK>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="5" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="3180" top="2760" width="1200" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="3180" top="2760" width="1200" height="270">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="|Enable me first|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (Enumerations)" componentmode="InABox" id="6" systemname="IOBox (Enumerations)">
+   <BOUNDS type="Node" left="3435" top="3630" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="3435" top="3630" width="1590" height="240">
+   </BOUNDS>
+   <PIN pinname="Input Enum" slicecount="1" values="|loopMIDI Port|">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="|Midi Input Port|">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="6" srcpinname="Output Enum" dstnodeid="0" dstpinname="Midi Input Port">
+   </LINK>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="7" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="3435" top="3330" width="1695" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="3435" top="3330" width="1695" height="270">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="|Midi device to listen to|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="8" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Node" left="405" top="3435" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="405" top="3435" width="795" height="240">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Integer">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Channel">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="8" srcpinname="Y Output Value" dstnodeid="0" dstpinname="Channel">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="9" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Node" left="1335" top="2640" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="1335" top="2640" width="795" height="1065">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="4" values="60,62,64,65">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Integer">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Note">
+   </PIN>
+   <PIN pinname="Rows" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="SliceCount Mode" slicecount="1" values="ColsRowsPages">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="9" srcpinname="Y Output Value" dstnodeid="0" dstpinname="Note">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="11" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Node" left="2040" top="4695" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="2040" top="4695" width="570" height="1380">
+   </BOUNDS>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Boolean">
+   </PIN>
+   <PIN pinname="Behavior" slicecount="1" values="Bang">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="|On Data|">
+   </PIN>
+   <PIN pinname="Rows" slicecount="1" values="4">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="0" srcpinname="On Data" dstnodeid="11" dstpinname="Y Input Value">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="12" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Node" left="630" top="4695" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="630" top="4695" width="885" height="1350">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="4" visible="1" values="60,62,64,65">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Integer">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Output">
+   </PIN>
+   <PIN pinname="Rows" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="SliceCount Mode" slicecount="1" values="ColsRowsPages">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="0" srcpinname="Output" dstnodeid="12" dstpinname="Y Input Value">
+   </LINK>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="13" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="225" top="1095" width="5925" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="225" top="1095" width="3915" height="1305">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="|MidiNote outputs the velocity value of the specified notes on the channel specified. &cr;&lf;&cr;&lf;You have to specify all the notes of interest. (e.g. note number 60 equals note C4). Only the correspondending values will be output.|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   </NODE>
+   <NODE nodename="MidiNote (Devices)" componentmode="Hidden" id="14" systemname="MidiNote (Devices)">
+   <BOUNDS type="Node" left="7750" top="4025" width="2850" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="7750" top="4025" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <PIN pinname="Note" visible="1">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="15" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Node" left="7740" top="4725" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="7740" top="4725" width="795" height="240">
+   </BOUNDS>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="14" srcpinname="Output" dstnodeid="15" dstpinname="Y Input Value">
+   </LINK>
+   <NODE systemname="I (Spreads)" nodename="I (Spreads)" componentmode="Hidden" id="16">
+   <BOUNDS type="Node" left="8430" top="2655" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname=".. To [" slicecount="1" values="127">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="16" srcpinname="Output" dstnodeid="14" dstpinname="Note">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="17" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Node" left="7740" top="3300" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="7740" top="3300" width="795" height="240">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Integer">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Channel">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="17" srcpinname="Y Output Value" dstnodeid="14" dstpinname="Channel">
+   </LINK>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="18" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="7755" top="1395" width="5115" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="7755" top="1395" width="3075" height="540">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="|I (Spreads) comes in handy when you want to listen to a range of notes|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="19" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Node" left="7920" top="2115" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="7920" top="2115" width="705" height="240">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Integer">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="|[ From ..|">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="19" srcpinname="Y Output Value" dstnodeid="16" dstpinname="[ From ..">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="20" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Node" left="8820" top="2115" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="8820" top="2115" width="795" height="240">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" values="128">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Integer">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="|.. To [|">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="20" srcpinname="Y Output Value" dstnodeid="16" dstpinname=".. To [">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="21" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Node" left="9840" top="3090" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="9840" top="3090" width="480" height="480">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Boolean">
+   </PIN>
+   <PIN pinname="Behavior" slicecount="1" values="Toggle">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Enabled">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="21" srcpinname="Y Output Value" dstnodeid="14" dstpinname="Enabled">
+   </LINK>
+   <NODE nodename="IOBox (Enumerations)" componentmode="InABox" id="22" systemname="IOBox (Enumerations)">
+   <BOUNDS type="Node" left="10515" top="3420" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="10515" top="3420" width="1590" height="240">
+   </BOUNDS>
+   <PIN pinname="Input Enum" slicecount="1" values="|loopMIDI Port|">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="|Midi Input Port|">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="22" srcpinname="Output Enum" dstnodeid="14" dstpinname="Midi Input Port">
+   </LINK>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="23" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="555" top="7125" width="6720" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="555" top="7125" width="4785" height="945">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="|see  http://www.midimountain.com/midi/midi_note_numbers.html  for a list of MIDI note numbers and their mapping to the musical scale.|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="24" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="615" top="8325" width="705" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="615" top="8325" width="705" height="270">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="|also see|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   </NODE>
+   <NODE systemname="MidiShort (Devices)" nodename="MidiShort (Devices)" componentmode="Hidden" id="25">
+   <BOUNDS type="Node" left="1425" top="8310" width="100" height="100">
+   </BOUNDS>
+   </NODE>
+   <NODE systemname="MidiController (Devices)" nodename="MidiController (Devices)" componentmode="Hidden" id="26">
+   <BOUNDS type="Node" left="2535" top="8310" width="100" height="100">
+   </BOUNDS>
+   </NODE>
+   <NODE systemname="MidiBend (Devices)" nodename="MidiBend (Devices)" componentmode="Hidden" id="27">
+   <BOUNDS type="Node" left="2430" top="8745" width="100" height="100">
+   </BOUNDS>
+   </NODE>
+   <NODE systemname="MidiSysex (Devices)" nodename="MidiSysex (Devices)" componentmode="Hidden" id="28">
+   <BOUNDS type="Node" left="1455" top="8745" width="100" height="100">
+   </BOUNDS>
+   </NODE>
+   <NODE systemname="MidiProgram (Devices)" nodename="MidiProgram (Devices)" componentmode="Hidden" id="29">
+   <BOUNDS type="Node" left="3720" top="8310" width="100" height="100">
+   </BOUNDS>
+   </NODE>
+   <NODE systemname="Count (Value)" nodename="Count (Value)" componentmode="Hidden" id="30">
+   <BOUNDS type="Node" left="8775" top="4665" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="14" srcpinname="Output" dstnodeid="30" dstpinname="Input">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="31" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Node" left="8790" top="5055" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="8790" top="5055" width="795" height="240">
+   </BOUNDS>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Integer">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="30" srcpinname="Count" dstnodeid="31" dstpinname="Y Input Value">
+   </LINK>
+   <NODE systemname="MidiShort (Devices)" nodename="MidiShort (Devices)" componentmode="Hidden" id="42">
+   <BOUNDS type="Node" left="7650" top="8235" width="3315" height="270">
+   </BOUNDS>
+   <PIN pinname="Message" visible="1">
+   </PIN>
+   </NODE>
+   <NODE componentmode="Hidden" id="41" nodename="SpellValue (String)" systemname="SpellValue (String)">
+   <BOUNDS height="0" left="7650" top="10125" type="Node" width="0">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   <PIN pinname="Mode" slicecount="1" values="Hex">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   </NODE>
+   <NODE componentmode="InABox" id="40" nodename="IOBox (String)" systemname="IOBox (String)">
+   <BOUNDS height="0" left="7650" top="10530" type="Node" width="0">
+   </BOUNDS>
+   <BOUNDS height="240" left="7650" top="10530" type="Box" width="795">
+   </BOUNDS>
+   <BOUNDS height="160" left="20205" top="7545" type="Window" width="215">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="1">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="|Message Hex|">
+   </PIN>
+   </NODE>
+   <LINK dstnodeid="40" dstpinname="Input String" srcnodeid="41" srcpinname="Output">
+   </LINK>
+   <LINK srcnodeid="42" srcpinname="Message" dstnodeid="41" dstpinname="Input">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="39" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Node" left="8310" top="9420" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="8310" top="9420" width="795" height="240">
+   </BOUNDS>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Integer">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="|Data 1|">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="42" srcpinname="Data 1" dstnodeid="39" dstpinname="Y Input Value">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="38" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Node" left="8970" top="8730" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="8970" top="8730" width="795" height="240">
+   </BOUNDS>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Integer">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="|Data 2|">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="42" srcpinname="Data 2" dstnodeid="38" dstpinname="Y Input Value">
+   </LINK>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="37" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="7680" top="6825" width="7785" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="7680" top="6825" width="4605" height="525">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="|If you are not sure which note numbers your device sends, you can use MidiShort to find the channel and note numbers.|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (Enumerations)" componentmode="InABox" id="36" systemname="IOBox (Enumerations)">
+   <BOUNDS type="Node" left="10905" top="7455" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="10905" top="7455" width="1590" height="240">
+   </BOUNDS>
+   <PIN pinname="Input Enum" slicecount="1" values="|loopMIDI Port|">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="|Midi Input Port|">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="36" srcpinname="Output Enum" dstnodeid="42" dstpinname="Midi Input Port">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="35" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Node" left="9825" top="7410" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="9825" top="7410" width="480" height="480">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Boolean">
+   </PIN>
+   <PIN pinname="Behavior" slicecount="1" values="Toggle">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Enabled">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="35" srcpinname="Y Output Value" dstnodeid="42" dstpinname="Enabled">
+   </LINK>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="34" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="8460" top="10110" width="7275" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="8460" top="10110" width="4935" height="1785">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="|Encoded in the message is the type of command and the MIDI channel on which the command is sent:&cr;&lf;In Hex notation the first digit specifies the type of command, the second digit specifies the channel:&cr;&lf;&cr;&lf;E.g.: 92 means: &cr;&lf;Command: 9 = NoteOn&cr;&lf;Channel   : 2 |">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="33" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="9135" top="9420" width="4020" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="9135" top="9420" width="5190" height="285">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="|Data byte 1 holds the note number of the NoteOn/NoteOff command|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="32" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="9765" top="8730" width="4440" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="9765" top="8730" width="4725" height="285">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="|Data byte 2 holds the velocity for the corresponding controller|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   </NODE>
+   </PATCH>

--- a/vvvv45/lib/nodes/native/MidiProgram (Devices) help.v4p
+++ b/vvvv45/lib/nodes/native/MidiProgram (Devices) help.v4p
@@ -1,0 +1,165 @@
+<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45alpha29.3.dtd" >
+   <PATCH nodename="C:\vvvv\git\vvvv-sdk\vvvv45\lib\nodes\native\MidiProgram (Devices) help.v4p">
+   <BOUNDS type="Window" left="5010" top="3210" width="11115" height="8700">
+   </BOUNDS>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="3" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="150" top="150" width="5000" height="450">
+   </BOUNDS>
+   <BOUNDS type="Box" left="150" top="150" width="5000" height="450">
+   </BOUNDS>
+   <PIN pinname="Input String" slicecount="1" visible="0" values="|MidiProgram (Devices)|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Size" slicecount="1" visible="1" values="14">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="2" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="150" top="550" width="5000" height="500">
+   </BOUNDS>
+   <BOUNDS type="Box" left="150" top="550" width="5000" height="500">
+   </BOUNDS>
+   <PIN pinname="Input String" slicecount="1" visible="0" values="|Handles midi ProgramChange commands|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   </NODE>
+   <NODE nodename="MidiProgram (Devices)" componentmode="Hidden" id="0" systemname="MidiProgram (Devices)">
+   <BOUNDS type="Node" left="1825" top="4025" width="2910" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="1825" top="4025" width="0" height="0">
+   </BOUNDS>
+   </NODE>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="4" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="1800" top="1770" width="7230" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="1800" top="1770" width="3990" height="555">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="|MidiProgram outputs the program change commands on the specified channels.|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="5" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Node" left="1845" top="3150" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="1845" top="3150" width="735" height="480">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="2" values="0,4">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Integer">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Channel">
+   </PIN>
+   <PIN pinname="Rows" slicecount="1" values="2">
+   </PIN>
+   <PIN pinname="SliceCount Mode" slicecount="1" values="ColsRowsPages">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="5" srcpinname="Y Output Value" dstnodeid="0" dstpinname="Channel">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="6" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Node" left="3720" top="2610" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="3720" top="2610" width="480" height="480">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Boolean">
+   </PIN>
+   <PIN pinname="Behavior" slicecount="1" values="Toggle">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Enabled">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="6" srcpinname="Y Output Value" dstnodeid="0" dstpinname="Enabled">
+   </LINK>
+   <NODE nodename="IOBox (Enumerations)" componentmode="InABox" id="7" systemname="IOBox (Enumerations)">
+   <BOUNDS type="Node" left="4680" top="3375" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="4680" top="3375" width="1590" height="240">
+   </BOUNDS>
+   <PIN pinname="Input Enum" slicecount="1" values="|loopMIDI Port|">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="|Midi Input Port|">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="7" srcpinname="Output Enum" dstnodeid="0" dstpinname="Midi Input Port">
+   </LINK>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="8" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="4200" top="2610" width="1200" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="4200" top="2610" width="1200" height="270">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="|Enable me first|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="9" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Node" left="1830" top="5700" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="1830" top="5700" width="840" height="540">
+   </BOUNDS>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Output">
+   </PIN>
+   <PIN pinname="Rows" slicecount="1" values="2">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="0" srcpinname="Output" dstnodeid="9" dstpinname="Y Input Value">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="10" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Node" left="3270" top="4650" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="3270" top="4650" width="480" height="480">
+   </BOUNDS>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Boolean">
+   </PIN>
+   <PIN pinname="Behavior" slicecount="1" values="Bang">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="|On Data|">
+   </PIN>
+   <PIN pinname="Rows" slicecount="1" values="2">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="0" srcpinname="On Data" dstnodeid="10" dstpinname="Y Input Value">
+   </LINK>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="11" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="2715" top="6210" width="4170" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="2715" top="6210" width="4170" height="270">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="|The new program number on the corresponding channel|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   </NODE>
+   </PATCH>

--- a/vvvv45/lib/nodes/native/MidiShortOutput (Devices) help.v4p
+++ b/vvvv45/lib/nodes/native/MidiShortOutput (Devices) help.v4p
@@ -1,0 +1,277 @@
+<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45alpha29.3.dtd" >
+   <PATCH nodename="C:\vvvv\git\vvvv-sdk\vvvv45\lib\nodes\native\MidiShortOutput (Devices) help.v4p">
+   <BOUNDS type="Window" left="4560" top="2880" width="12180" height="9930">
+   </BOUNDS>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="3" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="150" top="150" width="5000" height="450">
+   </BOUNDS>
+   <BOUNDS type="Box" left="150" top="150" width="5000" height="450">
+   </BOUNDS>
+   <PIN pinname="Input String" slicecount="1" visible="0" values="|MidiShortOutput (Devices)|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Size" slicecount="1" visible="1" values="14">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="2" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="150" top="550" width="5000" height="500">
+   </BOUNDS>
+   <BOUNDS type="Box" left="150" top="550" width="5000" height="500">
+   </BOUNDS>
+   <PIN pinname="Input String" slicecount="1" visible="0" values="|Sends a midi message|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   </NODE>
+   <NODE nodename="MidiShortOutput (Devices)" componentmode="Hidden" id="0" systemname="MidiShortOutput (Devices)">
+   <BOUNDS type="Node" left="3250" top="8795" width="3810" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="3250" top="8795" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Message" visible="1">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="4" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="135" top="1110" width="6420" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="135" top="1110" width="6960" height="945">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="|Allows for sending a midi message specified by the values for status bytes and data bytes. Read about how MIDI messages are being constructed here: &cr;&lf;&cr;&lf;http://www.midi.org/techspecs/midimessages.php|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   </NODE>
+   <NODE systemname="Ord (String)" nodename="Ord (String)" componentmode="Hidden" id="5">
+   <BOUNDS type="Node" left="3990" top="5835" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Format" slicecount="1" values="HexUnsigned8Bit">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="6" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="3990" top="5460" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="3990" top="5460" width="690" height="300">
+   </BOUNDS>
+   <PIN pinname="Input String" slicecount="1" values="CF">
+   </PIN>
+   <PIN pinname="Default" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="File Mask" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Maximum Characters" slicecount="1" values="-1">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="6" srcpinname="Output String" dstnodeid="5" dstpinname="Input">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="7" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Node" left="3990" top="6225" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="3990" top="6225" width="795" height="240">
+   </BOUNDS>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Y Output Value" visible="1">
+   </PIN>
+   <PIN pinname="Y Input Value" visible="1" slicecount="1" values="176">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Message">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="8" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Node" left="4770" top="7860" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="4770" top="7860" width="795" height="240">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Integer">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Data1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="8" srcpinname="Y Output Value" dstnodeid="0" dstpinname="Data1">
+   </LINK>
+   <LINK srcnodeid="7" srcpinname="Y Output Value" dstnodeid="0" dstpinname="Message">
+   </LINK>
+   <LINK srcnodeid="5" srcpinname="Output" dstnodeid="7" dstpinname="Y Input Value">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="9" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Node" left="5850" top="7875" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="5850" top="7875" width="795" height="240">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Integer">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Data2">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="9" srcpinname="Y Output Value" dstnodeid="0" dstpinname="Data2">
+   </LINK>
+   <NODE nodename="IOBox (Enumerations)" componentmode="InABox" id="10" systemname="IOBox (Enumerations)">
+   <BOUNDS type="Node" left="7035" top="8310" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="7035" top="8310" width="1590" height="240">
+   </BOUNDS>
+   <PIN pinname="Input Enum" slicecount="1" values="|Microsoft GS Wavetable Synth|">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="10" srcpinname="Output Enum" dstnodeid="0" dstpinname="Midi Output Port">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="11" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Node" left="7320" top="7350" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="7320" top="7350" width="480" height="480">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Boolean">
+   </PIN>
+   <PIN pinname="Behavior" slicecount="1" values="Toggle">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Enabled">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="11" srcpinname="Y Output Value" dstnodeid="0" dstpinname="Enabled">
+   </LINK>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="12" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="4905" top="2865" width="3090" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="4905" top="2865" width="5100" height="3810">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="|The statusbyte is constructed as follows:&cr;&lf;The most significant 4 bits (M) of the statusbyte define the type of command, the least significant 4 bits (L) define the channel number:&cr;&lf;Statusbyte: MMMM LLLL&cr;&lf;e.g.: &cr;&lf;1001 0001: command NoteOn, channel 1&cr;&lf;1011 0101: command ControlChange, channel 5&cr;&lf;1100 1111: command ProgramChange, channel 15 &cr;&lf;&cr;&lf;These commands can be written short in hexadecimal notation, where 4 bits can be written as one Hex digit. The commands from above are:&cr;&lf;&cr;&lf;1001 0001 -&gt; 91 (= decimal 145)&cr;&lf;1011 0101 -&gt; B5 (= decimal 181)&cr;&lf;1100 1111 -&gt; CF (= decimal 207)&cr;&lf;&cr;&lf;&lt;- The decimal value is finally used as input to the Message pin|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="13" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="3060" top="6210" width="885" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="3060" top="6210" width="885" height="270">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="Statusbyte">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="14" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Node" left="2805" top="7290" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="2805" top="7290" width="480" height="480">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Boolean">
+   </PIN>
+   <PIN pinname="Behavior" slicecount="1" values="Bang">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="|Do Send|">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="14" srcpinname="Y Output Value" dstnodeid="0" dstpinname="Do Send">
+   </LINK>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="15" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="5415" top="7440" width="840" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="5415" top="7440" width="840" height="270">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="Databytes">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   </NODE>
+   <NODE systemname="Bit (Value)" filename="%VVVV%\lib\nodes\modules\Value\Bit (Value).v4p" nodename="Bit (Value)" componentmode="Hidden" id="17" hiddenwhenlocked="1">
+   <BOUNDS type="Node" left="1920" top="4560" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   <PIN pinname="Bit" visible="1">
+   </PIN>
+   <PIN pinname="Inverse Output" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="5" srcpinname="Output" dstnodeid="17" dstpinname="Input" hiddenwhenlocked="1">
+   <LINKPOINT x="1620" y="6090">
+   </LINKPOINT>
+   </LINK>
+   <NODE systemname="I (Spreads)" nodename="I (Spreads)" componentmode="Hidden" id="18" hiddenwhenlocked="1">
+   <BOUNDS type="Node" left="2385" top="4185" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname=".. To [" slicecount="1" values="8">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="18" srcpinname="Output" dstnodeid="17" dstpinname="Bit" hiddenwhenlocked="1">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="19" systemname="IOBox (Value Advanced)" hiddenwhenlocked="0">
+   <BOUNDS type="Node" left="1935" top="5445" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="1935" top="5445" width="1935" height="240">
+   </BOUNDS>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Integer">
+   </PIN>
+   <PIN pinname="Columns" slicecount="1" values="9">
+   </PIN>
+   <PIN pinname="Y Input Value" visible="1">
+   </PIN>
+   </NODE>
+   <NODE systemname="Reverse (Spreads)" nodename="Reverse (Spreads)" componentmode="Hidden" id="20" hiddenwhenlocked="1">
+   <BOUNDS type="Node" left="1920" top="4980" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="17" srcpinname="Output" dstnodeid="20" dstpinname="Input">
+   </LINK>
+   <LINK srcnodeid="20" srcpinname="Output" dstnodeid="19" dstpinname="Y Input Value">
+   </LINK>
+   </PATCH>


### PR DESCRIPTION
Following issues were fixed:
- Inconsistencies in channel addressing
  - Some nodes expected channel numbers from 1-16 in Channel IOBox, some from 0-15. Now all expect 0-15 (as stated already in the helpfile)
  - Incorrect channel mapping and issues with resetting pins: Setting Channel 15 to some of the nodes would result in incorrect sending on channel 0. Reason for that was the use of the Map(Value) node with wrapping. Also, resetting pins/nodes would result in improper channel numbers (0.5). -> Replaced Map with Frac and Mod. Nodes/Pins behave as expected now.
- Inconsistencies with pins
  -  some modules had an "Enabled" and "MidiOutputPort" pin, some did not. Now all have them.
- MidiControllerOut: Limited Controller number to values from 0 to 119 as defined in Midi specs ( http://www.midi.org/techspecs/midimessages.php )
