### PR TITLE
Added extra info to the Filestream (EX9.Texture VLC) help file

### DIFF
--- a/vvvv45/addonpack/lib/nodes/plugins/FileStream (EX9.Texture VLC) help.v4p
+++ b/vvvv45/addonpack/lib/nodes/plugins/FileStream (EX9.Texture VLC) help.v4p
@@ -1,11 +1,11 @@
-<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45alpha28.1.dtd" >
-   <PATCH nodename="C:\data\2\video\vvvv\_ft\development\vvvv-sdk\vvvv45\addonpack\lib\nodes\plugins\FileStream (VLC 0.1) help.v4p">
+<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45beta29.2.dtd" >
+   <PATCH nodename="C:\data\2\video\vvvv\_ft\development\vvvv-sdk\vvvv45\addonpack\lib\nodes\plugins\FileStream (EX9.Texture VLC) help.v4p">
    <BOUNDS height="9345" left="0" top="0" type="Window" width="14670">
    </BOUNDS>
    <NODE componentmode="Hidden" id="2" nodename="Quad (DX9)" systemname="Quad (DX9)">
-   <BOUNDS height="100" left="90" top="10230" type="Node" width="100">
+   <BOUNDS height="100" left="90" top="27330" type="Node" width="100">
    </BOUNDS>
-   <BOUNDS height="0" left="90" top="10230" type="Box" width="0">
+   <BOUNDS height="0" left="90" top="27330" type="Box" width="0">
    </BOUNDS>
    <BOUNDS height="0" left="7590" top="7530" type="Window" width="0">
    </BOUNDS>
@@ -17,9 +17,9 @@
    </PIN>
    </NODE>
    <NODE componentmode="InAWindow" id="3" nodename="Renderer (EX9)" systemname="RENDERER (EX9)">
-   <BOUNDS height="100" left="90" top="10980" type="Node" width="100">
+   <BOUNDS height="100" left="90" top="28530" type="Node" width="100">
    </BOUNDS>
-   <BOUNDS height="1800" left="90" top="10980" type="Box" width="2400">
+   <BOUNDS height="1800" left="90" top="28530" type="Box" width="2400">
    </BOUNDS>
    <BOUNDS height="4860" left="14760" top="0" type="Window" width="6120">
    </BOUNDS>
@@ -39,13 +39,13 @@
    </PIN>
    </NODE>
    <NODE componentmode="InABox" id="6" nodename="IOBox (String)" systemname="IOBox (String)">
-   <BOUNDS height="100" left="3165" top="345" type="Node" width="100">
+   <BOUNDS height="100" left="3165" top="6045" type="Node" width="100">
    </BOUNDS>
-   <BOUNDS height="1530" left="3165" top="345" type="Box" width="6585">
+   <BOUNDS height="1530" left="3165" top="6045" type="Box" width="6585">
    </BOUNDS>
    <BOUNDS height="160" left="6555" top="6405" type="Window" width="215">
    </BOUNDS>
-   <PIN encoded="0" pinname="Input String" slicecount="8" values="|click_red.avi || input-repeat=-1|,click_green.avi,click_blue.avi,|click_green.avi || vout-filter=transform || noaudio || video-filter=adjust{hue=120,gamma=2.}|,alphatest.png,alphatest2.png,|click_red.avi || input-repeat=-1 || start-time=0.4 || stop-time=0.8|,">
+   <PIN encoded="0" pinname="Input String" slicecount="8" values="|click_red.avi || input-repeat=-1|,click_green.avi,click_blue.avi,|click_green.avi || vout-filter=transform || noaudio || video-filter=adjust{hue=120,gamma=2.}|,alphatest.png,alphatest2.png,|click_blue.avi || input-repeat=-1 || start-time=0.4 || stop-time=0.8|,">
    </PIN>
    <PIN pinname="Rows" slicecount="1" values="8">
    </PIN>
@@ -55,9 +55,9 @@
    </PIN>
    </NODE>
    <NODE componentmode="Hidden" id="15" nodename="Counter (Animation)" systemname="Counter (Animation)">
-   <BOUNDS height="100" left="75" top="1455" type="Node" width="100">
+   <BOUNDS height="100" left="75" top="7155" type="Node" width="100">
    </BOUNDS>
-   <BOUNDS height="0" left="75" top="1455" type="Box" width="0">
+   <BOUNDS height="0" left="75" top="7155" type="Box" width="0">
    </BOUNDS>
    <BOUNDS height="0" left="10620" top="8730" type="Window" width="0">
    </BOUNDS>
@@ -77,9 +77,9 @@
    </PIN>
    </NODE>
    <NODE componentmode="InABox" id="16" nodename="IOBox (Value Advanced)" systemname="IOBOX (VALUE ADVANCED)">
-   <BOUNDS height="100" left="75" top="975" type="Node" width="100">
+   <BOUNDS height="100" left="75" top="6675" type="Node" width="100">
    </BOUNDS>
-   <BOUNDS height="240" left="75" top="975" type="Box" width="450">
+   <BOUNDS height="240" left="75" top="6675" type="Box" width="450">
    </BOUNDS>
    <BOUNDS height="160" left="8940" top="8055" type="Window" width="215">
    </BOUNDS>
@@ -101,27 +101,25 @@
    </PIN>
    </NODE>
    <NODE componentmode="Hidden" id="17" nodename="Group (EX9)" systemname="Group (EX9)">
-   <BOUNDS height="270" left="90" top="10605" type="Node" width="1485">
+   <BOUNDS height="270" left="90" top="28155" type="Node" width="1485">
    </BOUNDS>
-   <BOUNDS height="0" left="90" top="10605" type="Box" width="0">
+   <BOUNDS height="0" left="90" top="28155" type="Box" width="0">
    </BOUNDS>
    <BOUNDS height="0" left="10185" top="10650" type="Window" width="0">
    </BOUNDS>
-   <PIN pinname="Layer 1" visible="1">
+   <PIN pinname="Layer 1" visible="1" slicecount="1" values="||">
    </PIN>
    <PIN pinname="Layer" visible="1">
    </PIN>
    <PIN pinname="Layer 2" visible="1">
    </PIN>
    </NODE>
-   <LINK dstnodeid="17" dstpinname="Layer 1" srcnodeid="2" srcpinname="Layer">
-   </LINK>
    <LINK dstnodeid="3" dstpinname="Layers" srcnodeid="17" srcpinname="Layer">
    </LINK>
    <NODE componentmode="Hidden" filename="%VVVV%\modules\catweasel\Debug\PerfMeter (Debug).v4p" id="18" nodename="PerfMeter (Debug)" systemname="PerfMeter (Debug)">
-   <BOUNDS height="270" left="1515" top="10230" type="Node" width="1065">
+   <BOUNDS height="270" left="1515" top="27780" type="Node" width="1065">
    </BOUNDS>
-   <BOUNDS height="3600" left="1515" top="10230" type="Box" width="4800">
+   <BOUNDS height="3600" left="1515" top="27780" type="Box" width="4800">
    </BOUNDS>
    <BOUNDS height="6000" left="5625" top="4095" type="Window" width="10995">
    </BOUNDS>
@@ -133,9 +131,9 @@
    <LINK dstnodeid="17" dstpinname="Layer 2" srcnodeid="18" srcpinname="Layer">
    </LINK>
    <NODE componentmode="InAWindow" id="19" nodename="Renderer (TTY)" systemname="Renderer (TTY)">
-   <BOUNDS height="100" left="3465" top="10980" type="Node" width="100">
+   <BOUNDS height="100" left="3465" top="28530" type="Node" width="100">
    </BOUNDS>
-   <BOUNDS height="1800" left="3465" top="10980" type="Box" width="2400">
+   <BOUNDS height="1800" left="3465" top="28530" type="Box" width="2400">
    </BOUNDS>
    <BOUNDS height="3810" left="0" top="9090" type="Window" width="16875">
    </BOUNDS>
@@ -145,9 +143,9 @@
    </PIN>
    </NODE>
    <NODE componentmode="Hidden" id="-6" nodename="MainLoop (VVVV)" systemname="MainLoop (VVVV)">
-   <BOUNDS height="100" left="3465" top="10665" type="Node" width="100">
+   <BOUNDS height="100" left="3465" top="28215" type="Node" width="100">
    </BOUNDS>
-   <BOUNDS height="0" left="3465" top="10665" type="Box" width="0">
+   <BOUNDS height="0" left="3465" top="28215" type="Box" width="0">
    </BOUNDS>
    <BOUNDS height="0" left="7200" top="4680" type="Window" width="0">
    </BOUNDS>
@@ -157,9 +155,9 @@
    </PIN>
    </NODE>
    <NODE componentmode="InAWindow" id="20" nodename="Renderer (EX9)" systemname="RENDERER (EX9)">
-   <BOUNDS height="100" left="1755" top="10980" type="Node" width="100">
+   <BOUNDS height="100" left="1755" top="28530" type="Node" width="100">
    </BOUNDS>
-   <BOUNDS height="1800" left="1755" top="10980" type="Box" width="2400">
+   <BOUNDS height="1800" left="1755" top="28530" type="Box" width="2400">
    </BOUNDS>
    <BOUNDS height="4860" left="21840" top="450" type="Window" width="6120">
    </BOUNDS>
@@ -177,9 +175,9 @@
    </PIN>
    </NODE>
    <NODE componentmode="InABox" id="26" nodename="IOBox (Value Advanced)" systemname="IOBOX (VALUE ADVANCED)">
-   <BOUNDS height="100" left="9645" top="7260" type="Node" width="100">
+   <BOUNDS height="100" left="11220" top="14010" type="Node" width="100">
    </BOUNDS>
-   <BOUNDS height="1410" left="9645" top="7260" type="Box" width="360">
+   <BOUNDS height="1410" left="11220" top="14010" type="Box" width="360">
    </BOUNDS>
    <BOUNDS height="160" left="675" top="4635" type="Window" width="215">
    </BOUNDS>
@@ -201,7 +199,7 @@
    <LINK dstnodeid="20" dstpinname="Layers" srcnodeid="17" srcpinname="Layer">
    </LINK>
    <NODE componentmode="Hidden" id="50" nodename="KeyMatch (String)" systemname="Match (String)">
-   <BOUNDS height="100" left="75" top="375" type="Node" width="100">
+   <BOUNDS height="100" left="75" top="6075" type="Node" width="100">
    </BOUNDS>
    <PIN pinname="Input" visible="1">
    </PIN>
@@ -215,7 +213,7 @@
    </PIN>
    </NODE>
    <NODE componentmode="Hidden" id="51" nodename="TogEdge (Animation)" systemname="TogEdge (Animation)">
-   <BOUNDS height="100" left="75" top="675" type="Node" width="100">
+   <BOUNDS height="100" left="75" top="6375" type="Node" width="100">
    </BOUNDS>
    <PIN pinname="Input" visible="1">
    </PIN>
@@ -227,7 +225,7 @@
    <LINK dstnodeid="16" dstpinname="Y Input Value" srcnodeid="51" srcpinname="Up Edge">
    </LINK>
    <NODE componentmode="Hidden" id="53" nodename="Cross (2d)" systemname="Cross (2d)">
-   <BOUNDS height="100" left="255" top="9420" type="Node" width="100">
+   <BOUNDS height="100" left="255" top="26070" type="Node" width="100">
    </BOUNDS>
    <PIN pinname="X In" visible="1">
    </PIN>
@@ -239,25 +237,25 @@
    </PIN>
    </NODE>
    <NODE componentmode="Hidden" id="54" nodename="Transform (Transform 2d)" systemname="Transform (Transform 2d)">
-   <BOUNDS height="100" left="255" top="9870" type="Node" width="100">
+   <BOUNDS height="100" left="255" top="26520" type="Node" width="100">
    </BOUNDS>
    <PIN pinname="TranslateX" visible="1">
    </PIN>
    <PIN pinname="TranslateY" visible="1">
    </PIN>
-   <PIN pinname="ScaleX" slicecount="1" values="0.6">
+   <PIN pinname="ScaleX" slicecount="1" visible="1" values="0.6">
    </PIN>
    <PIN pinname="Transform Out" visible="1">
    </PIN>
-   <PIN pinname="ScaleY" slicecount="1" values="0.6">
+   <PIN pinname="ScaleY" slicecount="1" visible="1" values="0.6">
    </PIN>
    </NODE>
    <LINK dstnodeid="2" dstpinname="Transform" srcnodeid="54" srcpinname="Transform Out">
    </LINK>
    <NODE componentmode="InABox" id="60" nodename="IOBox (Value Advanced)" systemname="IOBOX (VALUE ADVANCED)">
-   <BOUNDS height="100" left="9240" top="5745" type="Node" width="100">
+   <BOUNDS height="100" left="9240" top="12495" type="Node" width="100">
    </BOUNDS>
-   <BOUNDS height="420" left="9240" top="5745" type="Box" width="795">
+   <BOUNDS height="420" left="9240" top="12495" type="Box" width="795">
    </BOUNDS>
    <PIN pinname="Rows" slicecount="1" values="2">
    </PIN>
@@ -269,9 +267,9 @@
    </PIN>
    </NODE>
    <NODE componentmode="InABox" id="61" nodename="IOBox (Value Advanced)" systemname="IOBOX (VALUE ADVANCED)">
-   <BOUNDS height="100" left="8595" top="5715" type="Node" width="100">
+   <BOUNDS height="100" left="8595" top="12465" type="Node" width="100">
    </BOUNDS>
-   <BOUNDS height="480" left="8595" top="5715" type="Box" width="480">
+   <BOUNDS height="480" left="8595" top="12465" type="Box" width="480">
    </BOUNDS>
    <PIN pinname="Show Value" slicecount="1" values="0">
    </PIN>
@@ -295,9 +293,9 @@
    </PIN>
    </NODE>
    <NODE componentmode="InABox" id="70" nodename="IOBox (String)" systemname="IOBox (String)">
-   <BOUNDS height="270" left="2625" top="45" type="Node" width="5880">
+   <BOUNDS height="270" left="2625" top="5745" type="Node" width="5880">
    </BOUNDS>
-   <BOUNDS height="240" left="2625" top="45" type="Box" width="7125">
+   <BOUNDS height="240" left="2625" top="5745" type="Box" width="7125">
    </BOUNDS>
    <PIN encoded="0" pinname="Input String" slicecount="1" visible="0" values="|dshow:// || dshow-vdev=USB-videodevice || dshow-adev=  || dshow-caching=200|">
    </PIN>
@@ -307,21 +305,21 @@
    </PIN>
    </NODE>
    <NODE componentmode="Hidden" id="71" nodename="Keyboard (System Global)" systemname="Keyboard (System Global Legacy)">
-   <BOUNDS height="100" left="75" top="75" type="Node" width="100">
+   <BOUNDS height="100" left="75" top="5775" type="Node" width="100">
    </BOUNDS>
    <PIN pinname="Keyboard Output" visible="1">
    </PIN>
-   <PIN pinname="Enabled" slicecount="1" values="1">
+   <PIN pinname="Enabled" slicecount="1" visible="1" values="1">
    </PIN>
    </NODE>
    <LINK dstnodeid="50" dstpinname="Input" srcnodeid="71" srcpinname="Keyboard Output">
    </LINK>
    <NODE componentmode="InABox" id="72" nodename="IOBox (String)" systemname="IOBox (String)">
-   <BOUNDS height="270" left="7980" top="3900" type="Node" width="1575">
+   <BOUNDS height="270" left="8805" top="3960" type="Node" width="1575">
    </BOUNDS>
-   <BOUNDS height="1305" left="7980" top="3900" type="Box" width="5415">
+   <BOUNDS height="1305" left="8805" top="3960" type="Box" width="5415">
    </BOUNDS>
-   <PIN encoded="0" pinname="Input String" slicecount="1" visible="0" values="|press N key for next&cr;&lf;press P key for prvious&cr;&lf;press S key for slicecount change|">
+   <PIN encoded="0" pinname="Input String" slicecount="1" visible="0" values="|press N key for next&cr;&lf;press P key for previous&cr;&lf;press S key for slicecount change|">
    </PIN>
    <PIN pinname="Output String" visible="0">
    </PIN>
@@ -333,9 +331,9 @@
    </PIN>
    </NODE>
    <NODE componentmode="InABox" id="73" nodename="IOBox (String)" systemname="IOBox (String)">
-   <BOUNDS height="270" left="10050" top="7290" type="Node" width="2580">
+   <BOUNDS height="270" left="11625" top="14040" type="Node" width="2580">
    </BOUNDS>
-   <BOUNDS height="1350" left="10050" top="7290" type="Box" width="1800">
+   <BOUNDS height="1350" left="11625" top="14040" type="Box" width="1800">
    </BOUNDS>
    <PIN encoded="0" pinname="Input String" slicecount="1" visible="0" values="|next files loaded/ready for playing|">
    </PIN>
@@ -347,9 +345,9 @@
    </PIN>
    </NODE>
    <NODE componentmode="InABox" id="74" nodename="IOBox (String)" systemname="IOBox (String)">
-   <BOUNDS height="270" left="11385" top="6885" type="Node" width="720">
+   <BOUNDS height="270" left="11385" top="13635" type="Node" width="720">
    </BOUNDS>
-   <BOUNDS height="420" left="11385" top="6885" type="Box" width="645">
+   <BOUNDS height="420" left="11385" top="13635" type="Box" width="645">
    </BOUNDS>
    <PIN encoded="0" pinname="Input String" slicecount="1" visible="0" values="VLC">
    </PIN>
@@ -361,9 +359,9 @@
    </PIN>
    </NODE>
    <NODE componentmode="InABox" id="75" nodename="IOBox (String)" systemname="IOBox (String)">
-   <BOUNDS height="270" left="9240" top="5460" type="Node" width="960">
+   <BOUNDS height="270" left="9240" top="12210" type="Node" width="960">
    </BOUNDS>
-   <BOUNDS height="270" left="9240" top="5460" type="Box" width="960">
+   <BOUNDS height="270" left="9240" top="12210" type="Box" width="960">
    </BOUNDS>
    <PIN encoded="0" pinname="Input String" slicecount="1" visible="0" values="|play speeds|">
    </PIN>
@@ -373,9 +371,9 @@
    </PIN>
    </NODE>
    <NODE componentmode="InABox" id="76" nodename="IOBox (String)" systemname="IOBox (String)">
-   <BOUNDS height="270" left="8595" top="5460" type="Node" width="690">
+   <BOUNDS height="270" left="8595" top="12210" type="Node" width="690">
    </BOUNDS>
-   <BOUNDS height="285" left="8595" top="5460" type="Box" width="435">
+   <BOUNDS height="285" left="8595" top="12210" type="Box" width="435">
    </BOUNDS>
    <PIN encoded="0" pinname="Input String" slicecount="1" visible="0" values="loop">
    </PIN>
@@ -385,9 +383,9 @@
    </PIN>
    </NODE>
    <NODE componentmode="InABox" id="78" nodename="IOBox (Value Advanced)" systemname="IOBOX (VALUE ADVANCED)">
-   <BOUNDS height="100" left="10770" top="5760" type="Node" width="100">
+   <BOUNDS height="100" left="10770" top="12510" type="Node" width="100">
    </BOUNDS>
-   <BOUNDS height="1095" left="10770" top="5760" type="Box" width="1260">
+   <BOUNDS height="1095" left="10770" top="12510" type="Box" width="1260">
    </BOUNDS>
    <PIN pinname="Y Output Value" visible="1">
    </PIN>
@@ -413,9 +411,9 @@
    </PIN>
    </NODE>
    <NODE componentmode="InABox" id="79" nodename="IOBox (String)" systemname="IOBox (String)">
-   <BOUNDS height="270" left="10770" top="5460" type="Node" width="615">
+   <BOUNDS height="270" left="10770" top="12210" type="Node" width="615">
    </BOUNDS>
-   <BOUNDS height="270" left="10770" top="5460" type="Box" width="615">
+   <BOUNDS height="270" left="10770" top="12210" type="Box" width="615">
    </BOUNDS>
    <PIN encoded="0" pinname="Input String" slicecount="1" visible="0" values="volume">
    </PIN>
@@ -425,9 +423,9 @@
    </PIN>
    </NODE>
    <NODE componentmode="InABox" id="82" nodename="IOBox (String)" systemname="IOBox (String)">
-   <BOUNDS height="270" left="60" top="11265" type="Node" width="1905">
+   <BOUNDS height="270" left="60" top="28815" type="Node" width="1905">
    </BOUNDS>
-   <BOUNDS height="270" left="60" top="11265" type="Box" width="1695">
+   <BOUNDS height="270" left="60" top="28815" type="Box" width="1695">
    </BOUNDS>
    <PIN encoded="0" pinname="Input String" slicecount="1" visible="0" values="|renderer on monitor 1|">
    </PIN>
@@ -437,9 +435,9 @@
    </PIN>
    </NODE>
    <NODE componentmode="InABox" id="84" nodename="IOBox (String)" systemname="IOBox (String)">
-   <BOUNDS height="270" left="1740" top="11265" type="Node" width="1905">
+   <BOUNDS height="270" left="1740" top="28815" type="Node" width="1905">
    </BOUNDS>
-   <BOUNDS height="270" left="1740" top="11265" type="Box" width="1905">
+   <BOUNDS height="270" left="1740" top="28815" type="Box" width="1905">
    </BOUNDS>
    <PIN encoded="0" pinname="Input String" slicecount="1" visible="0" values="|renderer on monitor 2|">
    </PIN>
@@ -449,9 +447,9 @@
    </PIN>
    </NODE>
    <NODE componentmode="InABox" id="87" nodename="IOBox (Value Advanced)" systemname="IOBOX (VALUE ADVANCED)">
-   <BOUNDS height="100" left="7980" top="5715" type="Node" width="100">
+   <BOUNDS height="100" left="7980" top="12465" type="Node" width="100">
    </BOUNDS>
-   <BOUNDS height="480" left="7980" top="5715" type="Box" width="480">
+   <BOUNDS height="480" left="7980" top="12465" type="Box" width="480">
    </BOUNDS>
    <PIN pinname="Show Value" slicecount="1" values="0">
    </PIN>
@@ -475,9 +473,9 @@
    </PIN>
    </NODE>
    <NODE componentmode="InABox" id="86" nodename="IOBox (String)" systemname="IOBox (String)">
-   <BOUNDS height="270" left="7980" top="5460" type="Node" width="690">
+   <BOUNDS height="270" left="7980" top="12210" type="Node" width="690">
    </BOUNDS>
-   <BOUNDS height="285" left="7980" top="5460" type="Box" width="435">
+   <BOUNDS height="285" left="7980" top="12210" type="Box" width="435">
    </BOUNDS>
    <PIN encoded="0" pinname="Input String" slicecount="1" visible="0" values="play">
    </PIN>
@@ -487,7 +485,7 @@
    </PIN>
    </NODE>
    <NODE componentmode="Hidden" id="88" nodename="Switch (String Input)" systemname="Switch (String Input)">
-   <BOUNDS height="100" left="2340" top="2295" type="Node" width="100">
+   <BOUNDS height="100" left="2340" top="7995" type="Node" width="100">
    </BOUNDS>
    <PIN pinname="Input 1" visible="1">
    </PIN>
@@ -499,9 +497,9 @@
    </PIN>
    </NODE>
    <NODE componentmode="InABox" id="89" nodename="IOBox (Value Advanced)" systemname="IOBOX (VALUE ADVANCED)">
-   <BOUNDS height="100" left="1800" top="2115" type="Node" width="100">
+   <BOUNDS height="100" left="1800" top="7815" type="Node" width="100">
    </BOUNDS>
-   <BOUNDS height="480" left="1800" top="2115" type="Box" width="480">
+   <BOUNDS height="480" left="1800" top="7815" type="Box" width="480">
    </BOUNDS>
    <PIN pinname="Show Value" slicecount="1" values="0">
    </PIN>
@@ -523,9 +521,9 @@
    <LINK dstnodeid="88" dstpinname="Switch" srcnodeid="89" srcpinname="Y Output Value">
    </LINK>
    <NODE componentmode="InABox" id="91" nodename="IOBox (String)" systemname="IOBox (String)">
-   <BOUNDS height="100" left="9795" top="345" type="Node" width="100">
+   <BOUNDS height="100" left="9795" top="6045" type="Node" width="100">
    </BOUNDS>
-   <BOUNDS height="1545" left="9795" top="345" type="Box" width="4485">
+   <BOUNDS height="1545" left="9795" top="6045" type="Box" width="4485">
    </BOUNDS>
    <BOUNDS height="160" left="6555" top="6405" type="Window" width="215">
    </BOUNDS>
@@ -539,9 +537,9 @@
    </PIN>
    </NODE>
    <NODE componentmode="InABox" id="92" nodename="IOBox (String)" systemname="IOBox (String)">
-   <BOUNDS height="270" left="9795" top="45" type="Node" width="5880">
+   <BOUNDS height="270" left="9795" top="5745" type="Node" width="5880">
    </BOUNDS>
-   <BOUNDS height="255" left="9795" top="45" type="Box" width="4485">
+   <BOUNDS height="255" left="9795" top="5745" type="Box" width="4485">
    </BOUNDS>
    <PIN encoded="0" pinname="Input String" slicecount="1" visible="0" values="|--&gt; example using a webcam|">
    </PIN>
@@ -553,7 +551,7 @@
    <LINK dstnodeid="88" dstpinname="Input 1" srcnodeid="70" srcpinname="Output String">
    </LINK>
    <NODE componentmode="Hidden" id="93" nodename="TogEdge (Animation)" systemname="TogEdge (Animation)">
-   <BOUNDS height="100" left="900" top="675" type="Node" width="100">
+   <BOUNDS height="100" left="900" top="6375" type="Node" width="100">
    </BOUNDS>
    <PIN pinname="Input" visible="1">
    </PIN>
@@ -565,7 +563,7 @@
    <LINK dstnodeid="15" dstpinname="Down" srcnodeid="93" srcpinname="Up Edge">
    </LINK>
    <NODE componentmode="Hidden" id="98" nodename="I (Spreads)" systemname="I (Spreads)">
-   <BOUNDS height="100" left="1125" top="3405" type="Node" width="100">
+   <BOUNDS height="100" left="1125" top="10155" type="Node" width="100">
    </BOUNDS>
    <PIN pinname="Output" visible="1">
    </PIN>
@@ -573,7 +571,7 @@
    </PIN>
    </NODE>
    <NODE componentmode="Hidden" id="99" nodename="Multiply (Value)" systemname="Multiply (Value)">
-   <BOUNDS height="100" left="1125" top="3705" type="Node" width="100">
+   <BOUNDS height="100" left="1125" top="10455" type="Node" width="100">
    </BOUNDS>
    <PIN pinname="Input 2" slicecount="1" values="2">
    </PIN>
@@ -585,9 +583,9 @@
    <LINK dstnodeid="99" dstpinname="Input 1" srcnodeid="98" srcpinname="Output">
    </LINK>
    <NODE componentmode="InABox" id="100" nodename="IOBox (Value Advanced)" systemname="IOBox (Value Advanced)">
-   <BOUNDS height="0" left="1320" top="2865" type="Node" width="0">
+   <BOUNDS height="0" left="1320" top="9615" type="Node" width="0">
    </BOUNDS>
-   <BOUNDS height="435" left="1320" top="2865" type="Box" width="405">
+   <BOUNDS height="435" left="1320" top="9615" type="Box" width="405">
    </BOUNDS>
    <PIN pinname="Y Input Value" visible="1">
    </PIN>
@@ -603,11 +601,13 @@
    </PIN>
    <PIN pinname="Size" slicecount="1" values="16">
    </PIN>
+   <PIN pinname="Y Output Value" visible="1">
+   </PIN>
    </NODE>
    <LINK dstnodeid="98" dstpinname=".. To [" srcnodeid="100" srcpinname="Y Output Value">
    </LINK>
    <NODE componentmode="Hidden" id="102" nodename="Add (Value)" systemname="Add (Value)">
-   <BOUNDS height="100" left="4635" top="4305" type="Node" width="100">
+   <BOUNDS height="100" left="4635" top="11055" type="Node" width="100">
    </BOUNDS>
    <PIN pinname="Input 2" slicecount="1" values="1">
    </PIN>
@@ -617,7 +617,7 @@
    </PIN>
    </NODE>
    <NODE componentmode="Hidden" id="104" nodename="GetSlice (String)" systemname="GetSlice (String)">
-   <BOUNDS height="100" left="180" top="4605" type="Node" width="100">
+   <BOUNDS height="100" left="180" top="11355" type="Node" width="100">
    </BOUNDS>
    <PIN pinname="Input" visible="1">
    </PIN>
@@ -629,7 +629,7 @@
    <LINK dstnodeid="104" dstpinname="Input" srcnodeid="88" srcpinname="Output">
    </LINK>
    <NODE componentmode="Hidden" id="105" nodename="GetSlice (String)" systemname="GetSlice (String)">
-   <BOUNDS height="100" left="3960" top="4605" type="Node" width="100">
+   <BOUNDS height="100" left="3960" top="11355" type="Node" width="100">
    </BOUNDS>
    <PIN pinname="Input" visible="1">
    </PIN>
@@ -639,7 +639,7 @@
    </PIN>
    </NODE>
    <NODE componentmode="Hidden" id="106" nodename="Add (Value)" systemname="Add (Value)">
-   <BOUNDS height="100" left="855" top="4005" type="Node" width="100">
+   <BOUNDS height="100" left="855" top="10755" type="Node" width="100">
    </BOUNDS>
    <PIN pinname="Input 1" visible="1">
    </PIN>
@@ -659,15 +659,15 @@
    <LINK dstnodeid="105" dstpinname="Input" srcnodeid="88" srcpinname="Output">
    </LINK>
    <LINK dstnodeid="102" dstpinname="Input 1" linkstyle="VHV" srcnodeid="106" srcpinname="Output">
-   <LINKPOINT x="885" y="4275">
+   <LINKPOINT x="885" y="11025">
    </LINKPOINT>
-   <LINKPOINT x="4665" y="4275">
+   <LINKPOINT x="4665" y="11025">
    </LINKPOINT>
    </LINK>
    <NODE componentmode="InABox" id="108" nodename="IOBox (String)" systemname="IOBox (String)">
-   <BOUNDS height="0" left="180" top="5145" type="Node" width="0">
+   <BOUNDS height="0" left="180" top="11895" type="Node" width="0">
    </BOUNDS>
-   <BOUNDS height="1650" left="180" top="5145" type="Box" width="3630">
+   <BOUNDS height="1650" left="180" top="11895" type="Box" width="3630">
    </BOUNDS>
    <PIN encoded="0" pinname="Default" slicecount="1" values="text">
    </PIN>
@@ -685,9 +685,9 @@
    <LINK dstnodeid="108" dstpinname="Input String" srcnodeid="104" srcpinname="Output">
    </LINK>
    <NODE componentmode="InABox" id="109" nodename="IOBox (String)" systemname="IOBox (String)">
-   <BOUNDS height="0" left="3960" top="5145" type="Node" width="0">
+   <BOUNDS height="0" left="3960" top="11895" type="Node" width="0">
    </BOUNDS>
-   <BOUNDS height="1650" left="3960" top="5145" type="Box" width="3630">
+   <BOUNDS height="1650" left="3960" top="11895" type="Box" width="3630">
    </BOUNDS>
    <PIN encoded="0" pinname="Default" slicecount="1" values="text">
    </PIN>
@@ -707,9 +707,9 @@
    <LINK dstnodeid="109" dstpinname="Input String" srcnodeid="105" srcpinname="Output">
    </LINK>
    <NODE componentmode="InABox" id="110" nodename="IOBox (Value Advanced)" systemname="IOBOX (VALUE ADVANCED)">
-   <BOUNDS height="100" left="900" top="975" type="Node" width="100">
+   <BOUNDS height="100" left="900" top="6675" type="Node" width="100">
    </BOUNDS>
-   <BOUNDS height="240" left="900" top="975" type="Box" width="450">
+   <BOUNDS height="240" left="900" top="6675" type="Box" width="450">
    </BOUNDS>
    <BOUNDS height="160" left="8940" top="8055" type="Window" width="215">
    </BOUNDS>
@@ -733,9 +733,9 @@
    <LINK dstnodeid="110" dstpinname="Y Input Value" srcnodeid="93" srcpinname="Up Edge">
    </LINK>
    <NODE componentmode="InABox" id="111" nodename="IOBox (String)" systemname="IOBox (String)">
-   <BOUNDS height="270" left="1815" top="2835" type="Node" width="1575">
+   <BOUNDS height="270" left="1815" top="9585" type="Node" width="1575">
    </BOUNDS>
-   <BOUNDS height="480" left="1815" top="2835" type="Box" width="2160">
+   <BOUNDS height="480" left="1815" top="9585" type="Box" width="2160">
    </BOUNDS>
    <PIN encoded="0" pinname="Input String" slicecount="1" visible="0" values="SLICECOUNT">
    </PIN>
@@ -747,9 +747,9 @@
    </PIN>
    </NODE>
    <NODE componentmode="Hidden" id="112" nodename="LinearSpread (Spreads)" systemname="LinearSpread (Spreads)">
-   <BOUNDS height="100" left="255" top="8820" type="Node" width="100">
+   <BOUNDS height="100" left="255" top="25470" type="Node" width="100">
    </BOUNDS>
-   <PIN pinname="Spread Count" slicecount="1" values="3">
+   <PIN pinname="Spread Count" slicecount="1" visible="1" values="2">
    </PIN>
    <PIN pinname="Output" visible="1">
    </PIN>
@@ -763,7 +763,7 @@
    <LINK dstnodeid="54" dstpinname="TranslateY" srcnodeid="53" srcpinname="Y Out">
    </LINK>
    <NODE componentmode="Hidden" id="113" nodename="Multiply (Value)" systemname="Multiply (Value)">
-   <BOUNDS height="100" left="420" top="9120" type="Node" width="100">
+   <BOUNDS height="100" left="420" top="25770" type="Node" width="100">
    </BOUNDS>
    <PIN pinname="Input 2" slicecount="1" values="-1">
    </PIN>
@@ -777,7 +777,7 @@
    <LINK dstnodeid="53" dstpinname="Y In" srcnodeid="113" srcpinname="Output">
    </LINK>
    <NODE componentmode="Hidden" id="116" nodename="Counter (Animation)" systemname="Counter (Animation)">
-   <BOUNDS height="100" left="4455" top="2610" type="Node" width="100">
+   <BOUNDS height="100" left="4455" top="8460" type="Node" width="100">
    </BOUNDS>
    <PIN pinname="Output" visible="1">
    </PIN>
@@ -795,9 +795,9 @@
    <LINK dstnodeid="100" dstpinname="Y Input Value" srcnodeid="116" srcpinname="Output">
    </LINK>
    <NODE componentmode="InABox" id="120" nodename="IOBox (Value Advanced)" systemname="IOBox (Value Advanced)">
-   <BOUNDS height="0" left="4455" top="2100" type="Node" width="0">
+   <BOUNDS height="0" left="4455" top="7800" type="Node" width="0">
    </BOUNDS>
-   <BOUNDS height="480" left="4455" top="2100" type="Box" width="480">
+   <BOUNDS height="480" left="4455" top="7800" type="Box" width="480">
    </BOUNDS>
    <PIN pinname="Y Input Value" visible="1">
    </PIN>
@@ -815,9 +815,9 @@
    <LINK dstnodeid="116" dstpinname="Up" srcnodeid="120" srcpinname="Y Output Value">
    </LINK>
    <NODE componentmode="InABox" id="121" nodename="IOBox (String)" systemname="IOBox (String)">
-   <BOUNDS height="0" left="4905" top="11370" type="Node" width="0">
+   <BOUNDS height="0" left="4905" top="28920" type="Node" width="0">
    </BOUNDS>
-   <BOUNDS height="735" left="4905" top="11370" type="Box" width="8385">
+   <BOUNDS height="735" left="4905" top="28920" type="Box" width="8385">
    </BOUNDS>
    <PIN encoded="0" pinname="Default" slicecount="1" values="text">
    </PIN>
@@ -828,8 +828,8 @@
    </NODE>
    <LINK dstnodeid="121" dstpinname="Input String" srcnodeid="19" srcpinname="String Output">
    </LINK>
-   <NODE componentmode="Hidden" id="122" nodename="Writer (File)" systemname="Writer (File)">
-   <BOUNDS height="100" left="3465" top="12330" type="Node" width="100">
+   <NODE componentmode="Hidden" id="122" nodename="Writer (File)" systemname="Writer (String)">
+   <BOUNDS height="100" left="3465" top="29880" type="Node" width="100">
    </BOUNDS>
    <PIN pinname="Content" visible="1">
    </PIN>
@@ -839,15 +839,17 @@
    </PIN>
    <PIN pinname="Write" visible="1">
    </PIN>
+   <PIN pinname="Encoding" slicecount="1" values="|System Default|">
+   </PIN>
    </NODE>
    <LINK dstnodeid="122" dstpinname="Content" linkstyle="VHV" srcnodeid="19" srcpinname="String Output">
-   <LINKPOINT x="4935" y="11600">
+   <LINKPOINT x="4935" y="29150">
    </LINKPOINT>
-   <LINKPOINT x="3495" y="11650">
+   <LINKPOINT x="3495" y="29200">
    </LINKPOINT>
    </LINK>
    <NODE componentmode="Hidden" id="123" nodename="Change (String)" systemname="Change (String)">
-   <BOUNDS height="100" left="4110" top="11730" type="Node" width="100">
+   <BOUNDS height="100" left="4110" top="29280" type="Node" width="100">
    </BOUNDS>
    <PIN pinname="Input" visible="1">
    </PIN>
@@ -855,13 +857,13 @@
    </PIN>
    </NODE>
    <LINK dstnodeid="123" dstpinname="Input" linkstyle="VHV" srcnodeid="19" srcpinname="String Output">
-   <LINKPOINT x="4935" y="11655">
+   <LINKPOINT x="4935" y="29205">
    </LINKPOINT>
-   <LINKPOINT x="4140" y="11655">
+   <LINKPOINT x="4140" y="29205">
    </LINKPOINT>
    </LINK>
    <NODE componentmode="Hidden" id="124" nodename="DynamicTexture (EX9.Texture Value)" systemname="DynamicTexture (EX9.Texture Value)">
-   <BOUNDS height="100" left="5025" top="9585" type="Node" width="100">
+   <BOUNDS height="100" left="2175" top="26685" type="Node" width="100">
    </BOUNDS>
    <PIN pinname="Alpha" slicecount="1" visible="1" values="0.5">
    </PIN>
@@ -881,7 +883,7 @@
    </PIN>
    </NODE>
    <NODE componentmode="Hidden" id="126" nodename="Count (Node)" systemname="Count (Node)">
-   <BOUNDS height="100" left="7380" top="8670" type="Node" width="100">
+   <BOUNDS height="100" left="180" top="24600" type="Node" width="100">
    </BOUNDS>
    <PIN pinname="Input" visible="1" slicecount="1" values="||">
    </PIN>
@@ -889,7 +891,7 @@
    </PIN>
    </NODE>
    <NODE componentmode="Hidden" id="127" nodename="Change (Animation)" systemname="Change (Animation)">
-   <BOUNDS height="100" left="7380" top="8970" type="Node" width="100">
+   <BOUNDS height="100" left="4530" top="25470" type="Node" width="100">
    </BOUNDS>
    <PIN pinname="Input" visible="1">
    </PIN>
@@ -899,11 +901,11 @@
    <LINK dstnodeid="127" dstpinname="Input" srcnodeid="126" srcpinname="Count">
    </LINK>
    <NODE componentmode="Hidden" id="128" nodename="Subtract (Value)" systemname="Subtract (Value)">
-   <BOUNDS height="100" left="6990" top="8985" type="Node" width="100">
+   <BOUNDS height="100" left="4140" top="26085" type="Node" width="100">
    </BOUNDS>
    <PIN pinname="Input 2" visible="1">
    </PIN>
-   <PIN pinname="Input 1" slicecount="1" values="9">
+   <PIN pinname="Input 1" slicecount="1" visible="1" values="9">
    </PIN>
    <PIN pinname="Output" visible="1">
    </PIN>
@@ -911,7 +913,7 @@
    <LINK dstnodeid="128" dstpinname="Input 2" srcnodeid="126" srcpinname="Count">
    </LINK>
    <NODE componentmode="Hidden" id="130" nodename="GetSpread (Spreads)" systemname="GetSpread (Spreads)">
-   <BOUNDS height="100" left="6180" top="9285" type="Node" width="100">
+   <BOUNDS height="100" left="3330" top="26385" type="Node" width="100">
    </BOUNDS>
    <PIN pinname="Count" visible="1">
    </PIN>
@@ -923,7 +925,7 @@
    <LINK dstnodeid="130" dstpinname="Count" srcnodeid="128" srcpinname="Output">
    </LINK>
    <NODE componentmode="Hidden" id="132" nodename="Cons (EX9.Texture)" systemname="Cons (EX9.Texture)">
-   <BOUNDS height="100" left="4530" top="9885" type="Node" width="100">
+   <BOUNDS height="100" left="1680" top="26985" type="Node" width="100">
    </BOUNDS>
    <PIN pinname="Texture In 1" visible="1" slicecount="1" values="||">
    </PIN>
@@ -941,7 +943,7 @@
    <LINK dstnodeid="124" dstpinname="Apply" srcnodeid="130" srcpinname="Output">
    </LINK>
    <NODE componentmode="Hidden" id="134" nodename="TogEdge (Animation)" systemname="TogEdge (Animation)">
-   <BOUNDS height="100" left="1740" top="675" type="Node" width="100">
+   <BOUNDS height="100" left="1740" top="6375" type="Node" width="100">
    </BOUNDS>
    <PIN pinname="Input" visible="1">
    </PIN>
@@ -949,9 +951,9 @@
    </PIN>
    </NODE>
    <NODE componentmode="InABox" id="133" nodename="IOBox (Value Advanced)" systemname="IOBOX (VALUE ADVANCED)">
-   <BOUNDS height="100" left="1740" top="975" type="Node" width="100">
+   <BOUNDS height="100" left="1740" top="6675" type="Node" width="100">
    </BOUNDS>
-   <BOUNDS height="240" left="1740" top="975" type="Box" width="450">
+   <BOUNDS height="240" left="1740" top="6675" type="Box" width="450">
    </BOUNDS>
    <BOUNDS height="160" left="8940" top="8055" type="Window" width="215">
    </BOUNDS>
@@ -977,9 +979,9 @@
    <LINK dstnodeid="134" dstpinname="Input" srcnodeid="50" srcpinname="S Output">
    </LINK>
    <NODE componentmode="InABox" id="136" nodename="IOBox (Value Advanced)" systemname="IOBox (Value Advanced)">
-   <BOUNDS height="0" left="4890" top="7230" type="Node" width="0">
+   <BOUNDS height="0" left="8055" top="13980" type="Node" width="0">
    </BOUNDS>
-   <BOUNDS height="1545" left="4890" top="7230" type="Box" width="435">
+   <BOUNDS height="1545" left="8055" top="13980" type="Box" width="435">
    </BOUNDS>
    <PIN encoded="0" pinname="Units" slicecount="1" values="||">
    </PIN>
@@ -997,9 +999,9 @@
    </PIN>
    </NODE>
    <NODE componentmode="InABox" id="137" nodename="IOBox (Value Advanced)" systemname="IOBox (Value Advanced)">
-   <BOUNDS height="0" left="6060" top="7230" type="Node" width="0">
+   <BOUNDS height="0" left="9645" top="13980" type="Node" width="0">
    </BOUNDS>
-   <BOUNDS height="1545" left="6060" top="7230" type="Box" width="435">
+   <BOUNDS height="1545" left="9645" top="13980" type="Box" width="435">
    </BOUNDS>
    <PIN encoded="0" pinname="Units" slicecount="1" values="||">
    </PIN>
@@ -1021,7 +1023,7 @@
    <LINK dstnodeid="120" dstpinname="Y Input Value" srcnodeid="134" srcpinname="Up Edge">
    </LINK>
    <NODE componentmode="Hidden" id="145" nodename="AND (Boolean)" systemname="AND (Boolean)">
-   <BOUNDS height="100" left="3645" top="12030" type="Node" width="100">
+   <BOUNDS height="100" left="3645" top="29580" type="Node" width="100">
    </BOUNDS>
    <PIN pinname="Input 2" visible="1">
    </PIN>
@@ -1035,9 +1037,9 @@
    <LINK dstnodeid="122" dstpinname="Write" srcnodeid="145" srcpinname="Output">
    </LINK>
    <NODE componentmode="InABox" id="146" nodename="IOBox (Value Advanced)" systemname="IOBox (Value Advanced)">
-   <BOUNDS height="0" left="3645" top="11730" type="Node" width="0">
+   <BOUNDS height="0" left="3645" top="29280" type="Node" width="0">
    </BOUNDS>
-   <BOUNDS height="240" left="3645" top="11730" type="Box" width="345">
+   <BOUNDS height="240" left="3645" top="29280" type="Box" width="345">
    </BOUNDS>
    <PIN pinname="Y Input Value" slicecount="1" values="0">
    </PIN>
@@ -1055,9 +1057,9 @@
    <LINK dstnodeid="145" dstpinname="Input 1" srcnodeid="146" srcpinname="Y Output Value">
    </LINK>
    <NODE componentmode="InABox" id="153" nodename="IOBox (Value Advanced)" systemname="IOBox (Value Advanced)">
-   <BOUNDS height="0" left="2535" top="7230" type="Node" width="0">
+   <BOUNDS height="0" left="4905" top="13980" type="Node" width="0">
    </BOUNDS>
-   <BOUNDS height="1545" left="2535" top="7230" type="Box" width="435">
+   <BOUNDS height="1545" left="4905" top="13980" type="Box" width="435">
    </BOUNDS>
    <PIN encoded="0" pinname="Units" slicecount="1" values="||">
    </PIN>
@@ -1075,9 +1077,9 @@
    </PIN>
    </NODE>
    <NODE componentmode="InABox" id="152" nodename="IOBox (Value Advanced)" systemname="IOBox (Value Advanced)">
-   <BOUNDS height="0" left="3705" top="7230" type="Node" width="0">
+   <BOUNDS height="0" left="6495" top="13980" type="Node" width="0">
    </BOUNDS>
-   <BOUNDS height="1545" left="3705" top="7230" type="Box" width="435">
+   <BOUNDS height="1545" left="6495" top="13980" type="Box" width="435">
    </BOUNDS>
    <PIN encoded="0" pinname="Units" slicecount="1" values="||">
    </PIN>
@@ -1095,9 +1097,9 @@
    </PIN>
    </NODE>
    <NODE componentmode="InABox" id="155" nodename="IOBox (Value Advanced)" systemname="IOBox (Value Advanced)">
-   <BOUNDS height="0" left="180" top="7230" type="Node" width="0">
+   <BOUNDS height="0" left="3330" top="13980" type="Node" width="0">
    </BOUNDS>
-   <BOUNDS height="1545" left="180" top="7230" type="Box" width="435">
+   <BOUNDS height="1545" left="3330" top="13980" type="Box" width="435">
    </BOUNDS>
    <PIN encoded="0" pinname="Units" slicecount="1" values="||">
    </PIN>
@@ -1115,9 +1117,9 @@
    </PIN>
    </NODE>
    <NODE componentmode="InABox" id="154" nodename="IOBox (Value Advanced)" systemname="IOBox (Value Advanced)">
-   <BOUNDS height="0" left="1350" top="7230" type="Node" width="0">
+   <BOUNDS height="0" left="1755" top="13980" type="Node" width="0">
    </BOUNDS>
-   <BOUNDS height="1545" left="1350" top="7230" type="Box" width="435">
+   <BOUNDS height="1545" left="1755" top="13980" type="Box" width="435">
    </BOUNDS>
    <PIN encoded="0" pinname="Units" slicecount="1" values="||">
    </PIN>
@@ -1135,7 +1137,7 @@
    </PIN>
    </NODE>
    <NODE systemname="Add (String)" nodename="Add (String)" componentmode="Hidden" id="157">
-   <BOUNDS type="Node" left="2895" top="1995" width="100" height="100">
+   <BOUNDS type="Node" left="2895" top="7695" width="100" height="100">
    </BOUNDS>
    <PIN pinname="Intersperse" visible="-1" pintype="Input" slicecount="1" values="None">
    </PIN>
@@ -1152,8 +1154,8 @@
    </LINK>
    <LINK srcnodeid="157" srcpinname="Output" dstnodeid="88" dstpinname="Input 2">
    </LINK>
-   <NODE systemname="FileStream (Vlc)" filename="%VVVV%\addonpack\lib\nodes\plugins\FileStreamVLC.dll" nodename="FileStream (Vlc)" componentmode="Hidden" id="158">
-   <BOUNDS type="Node" left="180" top="6945" width="11100" height="270">
+   <NODE systemname="FileStream (EX9.Texture VLC)" filename="%VVVV%\addonpack\lib\nodes\plugins\FileStreamVLC.dll" nodename="FileStream (Vlc)" componentmode="Hidden" id="158">
+   <BOUNDS type="Node" left="180" top="13695" width="11100" height="270">
    </BOUNDS>
    <PIN pinname="Play" visible="1">
    </PIN>
@@ -1184,8 +1186,6 @@
    <PIN pinname="Volume" visible="1">
    </PIN>
    </NODE>
-   <LINK srcnodeid="87" srcpinname="Y Output Value" dstnodeid="158" dstpinname="Play">
-   </LINK>
    <LINK srcnodeid="61" srcpinname="Y Output Value" dstnodeid="158" dstpinname="Loop">
    </LINK>
    <LINK srcnodeid="60" srcpinname="Y Output Value" dstnodeid="158" dstpinname="Speed">
@@ -1193,10 +1193,6 @@
    <LINK srcnodeid="108" srcpinname="Output String" dstnodeid="158" dstpinname="Filename">
    </LINK>
    <LINK srcnodeid="109" srcpinname="Output String" dstnodeid="158" dstpinname="NextFilename">
-   </LINK>
-   <LINK srcnodeid="158" srcpinname="Texture Out" dstnodeid="132" dstpinname="Texture In 1">
-   </LINK>
-   <LINK srcnodeid="158" srcpinname="Texture Out" dstnodeid="126" dstpinname="Input">
    </LINK>
    <LINK srcnodeid="158" srcpinname="Position" dstnodeid="155" dstpinname="Y Input Value">
    </LINK>
@@ -1212,12 +1208,168 @@
    </LINK>
    <LINK srcnodeid="158" srcpinname="Height" dstnodeid="137" dstpinname="Y Input Value">
    </LINK>
-   <NODE nodename="IOBox (String)" componentmode="InABox" id="159" systemname="IOBox (String)">
-   <BOUNDS type="Node" left="9795" top="2010" width="8745" height="270">
+   <LINK srcnodeid="78" srcpinname="Y Output Value" dstnodeid="158" dstpinname="Volume">
+   </LINK>
+   <NODE systemname="AND (Boolean)" nodename="AND (Boolean)" componentmode="Hidden" id="160">
+   <BOUNDS type="Node" left="7650" top="13095" width="100" height="100">
    </BOUNDS>
-   <BOUNDS type="Box" left="9795" top="2010" width="4440" height="1125">
+   <PIN pinname="Input 2" visible="1">
+   </PIN>
+   <PIN pinname="Input 1" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="87" srcpinname="Y Output Value" dstnodeid="160" dstpinname="Input 2">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="162" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Node" left="2790" top="3975" width="0" height="0">
    </BOUNDS>
-   <PIN pinname="Input String" visible="0" slicecount="1" values="|Since LibVLC 2.0, filters don&apos;t work anymore. Hopefully this functionality will be re-enabled somehow in a future version...|" encoded="0">
+   <BOUNDS type="Box" left="2790" top="3975" width="945" height="825">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Integer">
+   </PIN>
+   <PIN pinname="Y Output Value" visible="1">
+   </PIN>
+   <PIN pinname="Size" slicecount="1" values="32">
+   </PIN>
+   <PIN pinname="Minimum" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Maximum" slicecount="1" values="1">
+   </PIN>
+   </NODE>
+   <NODE systemname="SetSlice (Spreads)" nodename="SetSlice (Spreads)" componentmode="Hidden" id="163">
+   <BOUNDS type="Node" left="60" top="4680" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Index" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <PIN pinname="Input" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="Spread" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="162" srcpinname="Y Output Value" dstnodeid="163" dstpinname="Index">
+   </LINK>
+   <NODE systemname="GetSlice (Spreads)" nodename="GetSlice (Spreads)" componentmode="Hidden" id="164">
+   <BOUNDS type="Node" left="7650" top="9495" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="163" srcpinname="Output" dstnodeid="164" dstpinname="Input">
+   </LINK>
+   <LINK srcnodeid="160" srcpinname="Output" dstnodeid="158" dstpinname="Play">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="165" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Node" left="7650" top="9810" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="7650" top="9810" width="555" height="240">
+   </BOUNDS>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Boolean">
+   </PIN>
+   <PIN pinname="Behavior" slicecount="1" values="Toggle">
+   </PIN>
+   <PIN pinname="Y Output Value" visible="1">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Active">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="164" srcpinname="Output" dstnodeid="165" dstpinname="Y Input Value">
+   </LINK>
+   <LINK srcnodeid="165" srcpinname="Y Output Value" dstnodeid="160" dstpinname="Input 1">
+   </LINK>
+   <NODE systemname="FileStream (EX9.Texture VLC)" filename="%VVVV%\addonpack\lib\nodes\plugins\FileStreamVLC.dll" nodename="FileStream (EX9.Texture VLC)" componentmode="Hidden" id="166">
+   <BOUNDS type="Node" left="1050" top="18390" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Filename" visible="1">
+   </PIN>
+   <PIN pinname="Play" visible="1">
+   </PIN>
+   <PIN pinname="Texture Out" visible="1">
+   </PIN>
+   <PIN pinname="NextFilename" visible="1" slicecount="1" values="|FileStreamVLCHelp\click_red.avi || input-repeat=-1|,">
+   </PIN>
+   <PIN pinname="Volume" slicecount="1" values="0">
+   </PIN>
+   </NODE>
+   <NODE systemname="GetSlice (Spreads)" nodename="GetSlice (Spreads)" componentmode="Hidden" id="168">
+   <BOUNDS type="Node" left="120" top="17850" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <PIN pinname="Index" visible="1" slicecount="1" values="1">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="167" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Node" left="120" top="18165" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="120" top="18165" width="555" height="240">
+   </BOUNDS>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Boolean">
+   </PIN>
+   <PIN pinname="Behavior" slicecount="1" values="Toggle">
+   </PIN>
+   <PIN pinname="Y Output Value" visible="1">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Active">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="168" srcpinname="Output" dstnodeid="167" dstpinname="Y Input Value">
+   </LINK>
+   <LINK srcnodeid="163" srcpinname="Output" dstnodeid="168" dstpinname="Input">
+   </LINK>
+   <LINK srcnodeid="167" srcpinname="Y Output Value" dstnodeid="166" dstpinname="Play">
+   </LINK>
+   <NODE systemname="GetSpread (Spreads)" nodename="GetSpread (Spreads)" componentmode="Hidden" id="170">
+   <BOUNDS type="Node" left="60" top="4350" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="171" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Node" left="810" top="4080" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="810" top="4080" width="450" height="240">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" values="2">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Integer">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="171" srcpinname="Y Output Value" dstnodeid="170" dstpinname="Count">
+   </LINK>
+   <LINK srcnodeid="170" srcpinname="Output" dstnodeid="163" dstpinname="Spread">
+   </LINK>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="172" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="1350" top="4065" width="1230" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="1350" top="4065" width="1230" height="270">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="|Nr Of Examples|">
    </PIN>
    <PIN pinname="Output String" visible="0">
    </PIN>
@@ -1226,6 +1378,550 @@
    <PIN pinname="String Type" slicecount="1" values="MultiLine">
    </PIN>
    </NODE>
-   <LINK srcnodeid="78" srcpinname="Y Output Value" dstnodeid="158" dstpinname="Volume">
+   <NODE systemname="Queue (EX9.Texture)" nodename="Queue (EX9.Texture)" componentmode="Hidden" id="175">
+   <BOUNDS type="Node" left="1320" top="20310" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Frame Count" slicecount="1" values="16">
+   </PIN>
+   <PIN pinname="Texture In" visible="1">
+   </PIN>
+   <PIN pinname="Insert" visible="1">
+   </PIN>
+   <PIN pinname="Texture Out" visible="1">
+   </PIN>
+   </NODE>
+   <NODE systemname="Expr (Value Advanced)" filename="AdvExpr.dll" nodename="Expr (Value Advanced)" componentmode="Hidden" id="180">
+   <BOUNDS type="Node" left="1155" top="25155" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Term" slicecount="1" visible="1" pintype="Input" values="|return Math.Ceiling( Math.Sqrt( A ) );|">
+   </PIN>
+   <PIN pinname="A" slicecount="1" visible="1" values="1.5">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="180" srcpinname="Output" dstnodeid="112" dstpinname="Spread Count">
+   </LINK>
+   <NODE systemname="Multiply (Value)" nodename="Multiply (Value)" componentmode="Hidden" id="182">
+   <BOUNDS type="Node" left="4140" top="25785" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input 1" visible="1">
+   </PIN>
+   <PIN pinname="Input 2" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="180" srcpinname="Output" dstnodeid="182" dstpinname="Input 1">
+   </LINK>
+   <LINK srcnodeid="180" srcpinname="Output" dstnodeid="182" dstpinname="Input 2">
+   </LINK>
+   <LINK srcnodeid="182" srcpinname="Output" dstnodeid="128" dstpinname="Input 1">
+   </LINK>
+   <NODE systemname="Divide (Value)" nodename="Divide (Value)" componentmode="Hidden" id="183">
+   <BOUNDS type="Node" left="1050" top="26055" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input 2" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <PIN pinname="Input" slicecount="1" values="1.9">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="180" srcpinname="Output" dstnodeid="183" dstpinname="Input 2">
+   </LINK>
+   <LINK srcnodeid="183" srcpinname="Output" dstnodeid="54" dstpinname="ScaleX">
+   </LINK>
+   <LINK srcnodeid="183" srcpinname="Output" dstnodeid="54" dstpinname="ScaleY">
+   </LINK>
+   <LINK srcnodeid="126" srcpinname="Count" dstnodeid="180" dstpinname="A">
+   </LINK>
+   <NODE systemname="GetSlice (String)" nodename="GetSlice (String)" componentmode="Hidden" id="186">
+   <BOUNDS type="Node" left="2325" top="17715" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   <PIN pinname="Bin Size" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="Index" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   </NODE>
+   <NODE systemname="Add (Value)" nodename="Add (Value)" componentmode="Hidden" id="187">
+   <BOUNDS type="Node" left="2940" top="17415" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input 2" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="Input 1" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="187" srcpinname="Output" dstnodeid="186" dstpinname="Index">
+   </LINK>
+   <NODE systemname="GetSlice (String)" nodename="GetSlice (String)" componentmode="Hidden" id="190">
+   <BOUNDS type="Node" left="3375" top="18000" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1" slicecount="8" values="text">
+   </PIN>
+   <PIN pinname="Bin Size" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="Index" visible="1" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   </NODE>
+   <NODE systemname="Switch (Node Input)" nodename="Switch (Node Input)" componentmode="Hidden" id="191">
+   <BOUNDS type="Node" left="180" top="24060" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input 2" visible="1">
+   </PIN>
+   <PIN pinname="Input 1" visible="1">
+   </PIN>
+   <PIN pinname="Switch" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="158" srcpinname="Texture Out" dstnodeid="191" dstpinname="Input 1">
+   </LINK>
+   <LINK srcnodeid="162" srcpinname="Y Output Value" dstnodeid="191" dstpinname="Switch">
+   </LINK>
+   <LINK srcnodeid="191" srcpinname="Output" dstnodeid="126" dstpinname="Input">
+   </LINK>
+   <LINK srcnodeid="191" srcpinname="Output" dstnodeid="132" dstpinname="Texture In 1">
+   </LINK>
+   <LINK srcnodeid="2" srcpinname="Layer" dstnodeid="17" dstpinname="Layer 1">
+   </LINK>
+   <NODE systemname="FrameCounter (Animation)" nodename="FrameCounter (Animation)" componentmode="Hidden" id="194">
+   <BOUNDS type="Node" left="3825" top="19410" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Reset" visible="1">
+   </PIN>
+   <PIN pinname="Enable" visible="1">
+   </PIN>
+   <PIN pinname="Frame Count" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="167" srcpinname="Y Output Value" dstnodeid="194" dstpinname="Enable">
+   </LINK>
+   <NODE systemname="LT (Value)" nodename="LT (Value)" componentmode="Hidden" id="196">
+   <BOUNDS type="Node" left="3825" top="19710" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input 1" visible="1">
+   </PIN>
+   <PIN pinname="Input 2" slicecount="1" values="17">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="194" srcpinname="Frame Count" dstnodeid="196" dstpinname="Input 1">
+   </LINK>
+   <LINK srcnodeid="196" srcpinname="Output" dstnodeid="175" dstpinname="Insert">
+   </LINK>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="197" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="3780" top="3990" width="2910" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="3780" top="3990" width="3435" height="810">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="|Select which example you want to show|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   <PIN pinname="Size" slicecount="1" values="16">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="198" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="75" top="8835" width="5205" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="75" top="8835" width="14160" height="420">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="|Example 1: change slicecount, add filters to some files, volume, looping|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   <PIN pinname="Size" slicecount="1" values="12">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="199" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="75" top="15930" width="5205" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="75" top="15930" width="14160" height="420">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="|Example 2: difference between using or not using the nextfilename pin|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   <PIN pinname="Size" slicecount="1" values="12">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="200" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="135" top="23430" width="5205" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="135" top="23430" width="14160" height="420">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="|Output: show a grid of all textures output by the selected example|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   <PIN pinname="Size" slicecount="1" values="12">
+   </PIN>
+   </NODE>
+   <NODE systemname="GetSlice (Node)" nodename="GetSlice (Node)" componentmode="Hidden" id="201">
+   <BOUNDS type="Node" left="1320" top="19710" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input Node" visible="1">
+   </PIN>
+   <PIN pinname="Output Node" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="166" srcpinname="Texture Out" dstnodeid="201" dstpinname="Input Node">
+   </LINK>
+   <NODE systemname="GetSlice (Node)" nodename="GetSlice (Node)" componentmode="Hidden" id="202">
+   <BOUNDS type="Node" left="2910" top="19710" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input Node" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Index" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="Output Node" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="166" srcpinname="Texture Out" dstnodeid="202" dstpinname="Input Node">
+   </LINK>
+   <LINK srcnodeid="201" srcpinname="Output Node" dstnodeid="175" dstpinname="Texture In">
+   </LINK>
+   <NODE systemname="Queue (EX9.Texture)" nodename="Queue (EX9.Texture)" componentmode="Hidden" id="203">
+   <BOUNDS type="Node" left="2925" top="20310" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Frame Count" slicecount="1" values="16">
+   </PIN>
+   <PIN pinname="Texture In" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Insert" visible="1" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Texture Out" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="202" srcpinname="Output Node" dstnodeid="203" dstpinname="Texture In">
+   </LINK>
+   <LINK srcnodeid="196" srcpinname="Output" dstnodeid="203" dstpinname="Insert">
+   </LINK>
+   <NODE componentmode="Hidden" id="209" nodename="Quad (DX9)" systemname="Quad (DX9)">
+   <BOUNDS height="100" left="990" top="20835" type="Node" width="100">
+   </BOUNDS>
+   <BOUNDS height="0" left="990" top="20835" type="Box" width="0">
+   </BOUNDS>
+   <BOUNDS height="0" left="7590" top="7530" type="Window" width="0">
+   </BOUNDS>
+   <PIN pinname="Texture" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Layer" visible="1">
+   </PIN>
+   <PIN pinname="Transform" visible="1" slicecount="1" values="||">
+   </PIN>
+   </NODE>
+   <NODE systemname="Renderer (EX9)" nodename="Renderer (EX9)" componentmode="Hidden" id="210">
+   <BOUNDS type="Node" left="990" top="21135" width="100" height="100">
+   </BOUNDS>
+   <BOUNDS type="Box" left="990" top="21135" width="2400" height="1800">
+   </BOUNDS>
+   <BOUNDS type="Window" left="14730" top="4995" width="6240" height="5010">
+   </BOUNDS>
+   <PIN pinname="Layers" visible="1">
+   </PIN>
+   <PIN pinname="Backbuffer Width" slicecount="1" values="256">
+   </PIN>
+   <PIN pinname="Backbuffer Height" slicecount="1" values="256">
+   </PIN>
+   <PIN pinname="EX9 Out" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="209" srcpinname="Layer" dstnodeid="210" dstpinname="Layers">
+   </LINK>
+   <NODE componentmode="Hidden" id="213" nodename="Quad (DX9)" systemname="Quad (DX9)">
+   <BOUNDS height="100" left="2595" top="20835" type="Node" width="100">
+   </BOUNDS>
+   <BOUNDS height="0" left="2595" top="20835" type="Box" width="0">
+   </BOUNDS>
+   <BOUNDS height="0" left="7590" top="7530" type="Window" width="0">
+   </BOUNDS>
+   <PIN pinname="Texture" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Layer" visible="1">
+   </PIN>
+   <PIN pinname="Transform" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Texture Transform" visible="1" slicecount="1" values="||">
+   </PIN>
+   </NODE>
+   <NODE systemname="Renderer (EX9)" nodename="Renderer (EX9)" componentmode="Hidden" id="212">
+   <BOUNDS type="Node" left="2595" top="21135" width="100" height="100">
+   </BOUNDS>
+   <BOUNDS type="Box" left="2595" top="21135" width="2400" height="1800">
+   </BOUNDS>
+   <BOUNDS type="Window" left="17760" top="7890" width="6240" height="5010">
+   </BOUNDS>
+   <PIN pinname="Layers" visible="1">
+   </PIN>
+   <PIN pinname="Backbuffer Width" slicecount="1" values="256">
+   </PIN>
+   <PIN pinname="Backbuffer Height" slicecount="1" values="256">
+   </PIN>
+   <PIN pinname="EX9 Out" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="213" srcpinname="Layer" dstnodeid="212" dstpinname="Layers">
+   </LINK>
+   <NODE componentmode="Hidden" id="219" nodename="Cross (2d)" systemname="Cross (2d)">
+   <BOUNDS height="100" left="5655" top="19500" type="Node" width="100">
+   </BOUNDS>
+   <PIN pinname="X In" visible="1">
+   </PIN>
+   <PIN pinname="Y In" visible="1">
+   </PIN>
+   <PIN pinname="X Out" visible="1">
+   </PIN>
+   <PIN pinname="Y Out" visible="1">
+   </PIN>
+   </NODE>
+   <NODE componentmode="Hidden" id="218" nodename="Transform (Transform 2d)" systemname="Transform (Transform 2d)">
+   <BOUNDS height="100" left="5655" top="19950" type="Node" width="100">
+   </BOUNDS>
+   <PIN pinname="TranslateX" visible="1">
+   </PIN>
+   <PIN pinname="TranslateY" visible="1">
+   </PIN>
+   <PIN pinname="ScaleX" slicecount="1" visible="1" values="0.95">
+   </PIN>
+   <PIN pinname="Transform Out" visible="1">
+   </PIN>
+   <PIN pinname="ScaleY" slicecount="1" visible="1" values="0.95">
+   </PIN>
+   </NODE>
+   <NODE componentmode="Hidden" id="217" nodename="LinearSpread (Spreads)" systemname="LinearSpread (Spreads)">
+   <BOUNDS height="100" left="5655" top="18900" type="Node" width="100">
+   </BOUNDS>
+   <PIN pinname="Spread Count" slicecount="1" visible="1" values="4">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <PIN pinname="Width" slicecount="1" values="2">
+   </PIN>
+   </NODE>
+   <LINK dstnodeid="218" dstpinname="TranslateX" srcnodeid="219" srcpinname="X Out">
+   </LINK>
+   <LINK dstnodeid="218" dstpinname="TranslateY" srcnodeid="219" srcpinname="Y Out">
+   </LINK>
+   <NODE componentmode="Hidden" id="216" nodename="Multiply (Value)" systemname="Multiply (Value)">
+   <BOUNDS height="100" left="5655" top="19200" type="Node" width="100">
+   </BOUNDS>
+   <PIN pinname="Input 2" slicecount="1" values="-1">
+   </PIN>
+   <PIN pinname="Input 1" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   </NODE>
+   <LINK dstnodeid="216" dstpinname="Input 1" srcnodeid="217" srcpinname="Output">
+   </LINK>
+   <LINK srcnodeid="218" srcpinname="Transform Out" dstnodeid="209" dstpinname="Transform">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="220" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Node" left="6480" top="19515" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="6480" top="19515" width="795" height="240">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" values="0.46">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Y Output Value" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="220" srcpinname="Y Output Value" dstnodeid="218" dstpinname="ScaleX">
+   </LINK>
+   <LINK srcnodeid="220" srcpinname="Y Output Value" dstnodeid="218" dstpinname="ScaleY">
+   </LINK>
+   <LINK srcnodeid="218" srcpinname="Transform Out" dstnodeid="213" dstpinname="Transform">
+   </LINK>
+   <LINK srcnodeid="203" srcpinname="Texture Out" dstnodeid="213" dstpinname="Texture">
+   </LINK>
+   <LINK srcnodeid="175" srcpinname="Texture Out" dstnodeid="209" dstpinname="Texture">
+   </LINK>
+   <NODE systemname="Change (String)" nodename="Change (String)" componentmode="Hidden" id="222">
+   <BOUNDS type="Node" left="4830" top="19110" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   <PIN pinname="OnChange" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="190" srcpinname="Output" dstnodeid="222" dstpinname="Input">
+   </LINK>
+   <LINK srcnodeid="222" srcpinname="OnChange" dstnodeid="194" dstpinname="Reset">
+   </LINK>
+   <LINK srcnodeid="15" srcpinname="Output" dstnodeid="190" dstpinname="Index">
+   </LINK>
+   <LINK srcnodeid="15" srcpinname="Output" dstnodeid="187" dstpinname="Input 1">
+   </LINK>
+   <LINK srcnodeid="190" srcpinname="Output" dstnodeid="166" dstpinname="Filename">
+   </LINK>
+   <LINK srcnodeid="217" srcpinname="Output" dstnodeid="219" dstpinname="Y In">
+   </LINK>
+   <LINK srcnodeid="216" srcpinname="Output" dstnodeid="219" dstpinname="X In">
+   </LINK>
+   <NODE systemname="DX9Texture (EX9.Texture)" nodename="DX9Texture (EX9.Texture)" componentmode="Hidden" id="225">
+   <BOUNDS type="Node" left="2430" top="21435" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Source" visible="1">
+   </PIN>
+   <PIN pinname="Texture Out" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="210" srcpinname="EX9 Out" dstnodeid="225" dstpinname="Source">
+   </LINK>
+   <NODE systemname="DX9Texture (EX9.Texture)" nodename="DX9Texture (EX9.Texture)" componentmode="Hidden" id="226">
+   <BOUNDS type="Node" left="4035" top="21435" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Source" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Texture Out" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="212" srcpinname="EX9 Out" dstnodeid="226" dstpinname="Source">
+   </LINK>
+   <NODE systemname="Cons (EX9.Texture)" nodename="Cons (EX9.Texture)" componentmode="Hidden" id="227">
+   <BOUNDS type="Node" left="810" top="22350" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Texture In Count" slicecount="1" values="3">
+   </PIN>
+   <PIN pinname="Texture In 1" visible="1">
+   </PIN>
+   <PIN pinname="Texture Out" visible="1">
+   </PIN>
+   <PIN pinname="Texture In 2" visible="1">
+   </PIN>
+   <PIN pinname="Texture In 3" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="166" srcpinname="Texture Out" dstnodeid="227" dstpinname="Texture In 1">
+   </LINK>
+   <LINK srcnodeid="227" srcpinname="Texture Out" dstnodeid="191" dstpinname="Input 2">
+   </LINK>
+   <LINK srcnodeid="225" srcpinname="Texture Out" dstnodeid="227" dstpinname="Texture In 2">
+   </LINK>
+   <LINK srcnodeid="226" srcpinname="Texture Out" dstnodeid="227" dstpinname="Texture In 3">
+   </LINK>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="228" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="420" top="16530" width="18765" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="420" top="16530" width="7515" height="810">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="|Below each video, you will see the 16 frames right after you pressed N. As you can see, the right side, which is using the NextFileName Pin correctly (it does contain the next file, so that it can be preloaded), manages to show the first frame of the next file instanly...|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   <PIN pinname="Size" slicecount="1" values="8">
+   </PIN>
+   </NODE>
+   <NODE systemname="GetSpread (String)" nodename="GetSpread (String)" componentmode="Hidden" id="232">
+   <BOUNDS type="Node" left="1875" top="17415" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   <PIN pinname="Count" slicecount="1" values="7">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="157" srcpinname="Output" dstnodeid="232" dstpinname="Input">
+   </LINK>
+   <LINK srcnodeid="232" srcpinname="Output" dstnodeid="190" dstpinname="Input">
+   </LINK>
+   <LINK srcnodeid="232" srcpinname="Output" dstnodeid="186" dstpinname="Input">
+   </LINK>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="233" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="90" top="15" width="1605" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="90" top="15" width="14145" height="3885">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="|Why is the node red?&cr;&lf;* Probably you haven&apos;t installed VLC player (download it at http://www.videolan.org/) or the wrong version (install VLC 32-bit for 32-bit builds of vvvv and VLC 64-bit for 64-bit builds of vvvv)&cr;&lf;* The plugin can&apos;t find VLC player, because it&apos;s not installed in the default location. In this case, edit the file %vvv%\addonpack\lib\nodes\plugins\libvlc_searchpath.txt and add the path to the VLC player installation you want to use.&cr;&lf;&cr;&lf;Which version of VLC player should I install?&cr;&lf;* Filters (like video-filter=... or deinterlace) don&apos;t work anymore in VLC 2.x, so if you want them, use VLC 1.1.x&cr;&lf;* There seem to be problems when you want to play streams with VLC 2.x (http, webcam, DVB-T etc.), so if you have any problems, try using VLC 1.1.x&cr;&lf;&cr;&lf;What are all possible filters that can be used?&cr;&lf;* I can&apos;t list them all here, but you can definitely find some inspiration on http://vvvv.org/contribution/dshow2vlc and on http://wiki.videolan.org/VLC_command-line_help. Remember to separate different filters with a pipe  ||  (and not : or - like they are used on the comandline and in VLC-player itself)&cr;&lf;&cr;&lf;Not all frames are played?&cr;&lf;* That&apos;s a bug in LibVLC, there&apos;s no cure at this time.&cr;&lf;&cr;&lf;Can I also use it to play plain audio files, and what about images?&cr;&lf;* Yes and yes&cr;&lf;|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="234" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="75" top="5265" width="5205" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="75" top="5265" width="14160" height="420">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="|Some filenames to use in the examples and some keyboard mappings|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   <PIN pinname="Size" slicecount="1" values="12">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="235" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Node" left="2490" top="18735" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="2490" top="18735" width="285" height="345">
+   </BOUNDS>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Boolean">
+   </PIN>
+   <PIN pinname="Behavior" slicecount="1" values="Toggle">
+   </PIN>
+   <PIN pinname="Rows" slicecount="1" values="2">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="166" srcpinname="Next Ready" dstnodeid="235" dstpinname="Y Input Value">
+   </LINK>
+   <NODE systemname="Cons (String)" filename="%VVVV%\lib\nodes\plugins\VVVV.Nodes.dll" nodename="Cons (String)" componentmode="Hidden" id="236">
+   <BOUNDS type="Node" left="1890" top="18015" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input 2" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="186" srcpinname="Output" dstnodeid="236" dstpinname="Input 2">
+   </LINK>
+   <LINK srcnodeid="236" srcpinname="Output" dstnodeid="166" dstpinname="NextFilename">
    </LINK>
    </PATCH>


### PR DESCRIPTION
The help file was not very complete and not of much use for users when the node was red. I hope these changes to the help file, give some more info on how to get the plugin working.
