### PR TITLE
Fixed wrong path building (one level up was missing form .git/hooks/)

### DIFF
--- a/scripts/fetch-binaries.ps1
+++ b/scripts/fetch-binaries.ps1
@@ -5,9 +5,9 @@ Param(
 )
 
 $scriptPath = Split-Path -Parent $MyInvocation.MyCommand.Definition
-$packagesPath = Join-Path $scriptPath "..\packages"
-$vvvvRootPath = Join-Path $scriptPath "..\vvvv45"
-$solutionPath = Join-Path $scriptPath "..\vvvv45\src"
+$packagesPath = Join-Path $scriptPath "..\..\packages"
+$vvvvRootPath = Join-Path $scriptPath "..\..\vvvv45"
+$solutionPath = Join-Path $scriptPath "..\..\vvvv45\src"
 $nugetExe = Join-Path $solutionPath  ".nuget\nuget.exe"
 $packageName = "VVVV.Binaries.$platform"
 $packageVersion = ""


### PR DESCRIPTION
Is related to this forum thread: http://vvvv.org/forum/vvvv-sdk-init-not-working
