### PR TITLE
Mark generic streams as public

### DIFF
--- a/vvvv45/src/core/Hosting/IO/Streams/PluginConfigStream.cs
+++ b/vvvv45/src/core/Hosting/IO/Streams/PluginConfigStream.cs
@@ -9,7 +9,7 @@ using VVVV.Utils.VColor;
 namespace VVVV.Hosting.IO.Streams
 {
     // Slow
-    abstract class PluginConfigStream<T> : MemoryIOStream<T>
+    public abstract class PluginConfigStream<T> : MemoryIOStream<T>
     {  
         private readonly IPluginConfig FPluginConfig;
         private bool FIsFlushing;

--- a/vvvv45/src/core/Hosting/IO/Streams/UnmanagedInStream.cs
+++ b/vvvv45/src/core/Hosting/IO/Streams/UnmanagedInStream.cs
@@ -13,7 +13,7 @@ using VVVV.Utils.VMath;
 
 namespace VVVV.Hosting.IO.Streams
 {
-    unsafe abstract class UnmanagedInStream<T> : IInStream<T>
+    public unsafe abstract class UnmanagedInStream<T> : IInStream<T>
     {
         internal abstract class UnmanagedInStreamReader : IStreamReader<T>
         {

--- a/vvvv45/src/core/Hosting/IO/Streams/UnmanagedOutStream.cs
+++ b/vvvv45/src/core/Hosting/IO/Streams/UnmanagedOutStream.cs
@@ -11,7 +11,7 @@ using VVVV.Utils;
 
 namespace VVVV.Hosting.IO.Streams
 {
-    unsafe abstract class UnmanagedOutStream<T> : IOutStream<T>
+    public unsafe abstract class UnmanagedOutStream<T> : IOutStream<T>
     {
         internal abstract class UnmanagedOutWriter : IStreamWriter<T>
         {

--- a/vvvv45/src/core/Hosting/IO/Streams/UnmanagedVectorInStream.cs
+++ b/vvvv45/src/core/Hosting/IO/Streams/UnmanagedVectorInStream.cs
@@ -8,7 +8,7 @@ using VVVV.Utils.VMath;
 
 namespace VVVV.Hosting.IO.Streams
 {
-    unsafe abstract class VectorInStream<T> : IInStream<T> where T : struct
+    public unsafe abstract class VectorInStream<T> : IInStream<T> where T : struct
     {
         internal abstract class VectorInStreamReader : IStreamReader<T>
         {

--- a/vvvv45/src/core/Hosting/IO/Streams/UnmanagedVectorOutStream.cs
+++ b/vvvv45/src/core/Hosting/IO/Streams/UnmanagedVectorOutStream.cs
@@ -8,7 +8,7 @@ using VVVV.Utils.VMath;
 
 namespace VVVV.Hosting.IO.Streams
 {
-    unsafe abstract class VectorOutStream<T> : IOutStream<T> where T : struct
+    public unsafe abstract class VectorOutStream<T> : IOutStream<T> where T : struct
     {
         internal abstract class VectorOutStreamWriter : IStreamWriter<T>
         {


### PR DESCRIPTION
So we can use them outside of hosting
