### PR TITLE
Take transforms into account in GetPath(SVG) node

### DIFF
--- a/vvvv45/src/nodes/plugins/SVG/SVGGeomNodes.cs
+++ b/vvvv45/src/nodes/plugins/SVG/SVGGeomNodes.cs
@@ -802,6 +802,8 @@ namespace VVVV.Nodes
 						{
 							p.Flatten(new System.Drawing.Drawing2D.Matrix(), FMaxFlattenInput[i] * 0.1f);
 						}
+						
+						p.Transform(elem.Transforms.GetMatrix());
 							          
 						po.SliceCount = p.PointCount;
 						pto.SliceCount = p.PointCount;


### PR DESCRIPTION
Translations and rotations are not carried over from SVG element nodes to GetPath(SVG) output. Not sure if you have any reason for this but from my perspective it looks like an oversight.
