### PR TITLE
ApplyTransform (Mouse) bugfix

### DIFF
--- a/vvvv45/lib/nodes/modules/Mouse/ApplyTransform (Mouse).v4p
+++ b/vvvv45/lib/nodes/modules/Mouse/ApplyTransform (Mouse).v4p
@@ -1,15 +1,15 @@
-<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45alpha32.2.dtd" >
-   <PATCH nodename="D:\gitHub\vvvv-sdk\vvvv45\lib\nodes\modules\Mouse\ApplyTransform (Mouse).v4p" systemname="ApplyTransform (Mouse)" filename="D:\gitHub\vvvv-sdk\vvvv45\lib\nodes\modules\Mouse\ApplyTransform (Mouse).v4p">
-   <BOUNDS type="Window" left="-23490" top="405" width="10230" height="7110">
+<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45alpha33.1.dtd" >
+   <PATCH nodename="D:\vvvv\vvvv_45alpha33.1_x86\vvvv_45alpha33.1_x86\lib\nodes\modules\Mouse\ApplyTransform (Mouse).v4p" systemname="ApplyTransform (Mouse)" filename="D:\gitHub\vvvv-sdk\vvvv45\lib\nodes\modules\Mouse\ApplyTransform (Mouse).v4p">
+   <BOUNDS type="Window" left="15795" top="2280" width="12120" height="7110">
    </BOUNDS>
    <PACK Name="VVVV.Packs" Version="0.1.0">
    </PACK>
-   <PACK Name="addonpack" Version="32.2.0">
+   <PACK Name="addonpack" Version="33.0.0">
    </PACK>
    <NODE systemname="IOBox (Node)" nodename="IOBox (Node)" componentmode="InABox" id="2">
-   <BOUNDS type="Node" left="4035" top="660" width="100" height="100">
+   <BOUNDS type="Node" left="4635" top="660" width="100" height="100">
    </BOUNDS>
-   <BOUNDS type="Box" left="4035" top="660" width="795" height="240">
+   <BOUNDS type="Box" left="4635" top="660" width="795" height="240">
    </BOUNDS>
    <PIN pinname="Descriptive Name" slicecount="1" values="|Mouse UnTransformed|">
    </PIN>
@@ -17,9 +17,9 @@
    </PIN>
    </NODE>
    <NODE systemname="IOBox (Node)" nodename="IOBox (Node)" componentmode="InABox" id="10">
-   <BOUNDS type="Node" left="1290" top="5790" width="100" height="100">
+   <BOUNDS type="Node" left="1890" top="5790" width="100" height="100">
    </BOUNDS>
-   <BOUNDS type="Box" left="1290" top="5790" width="795" height="240">
+   <BOUNDS type="Box" left="1890" top="5790" width="795" height="240">
    </BOUNDS>
    <PIN pinname="Descriptive Name" slicecount="1" values="|Mouse Transformed|">
    </PIN>
@@ -27,7 +27,7 @@
    </PIN>
    </NODE>
    <NODE systemname="MouseEvents (Mouse Join)" filename="%VVVV%\lib\nodes\plugins\VVVV.Nodes.dll" nodename="MouseEvents (Mouse Join)" componentmode="Hidden" id="11">
-   <BOUNDS type="Node" left="4020" top="4500" width="100" height="100">
+   <BOUNDS type="Node" left="4620" top="4500" width="100" height="100">
    </BOUNDS>
    <PIN pinname="Mouse" visible="1">
    </PIN>
@@ -51,11 +51,11 @@
    </PIN>
    <PIN pinname="PositionXY" visible="1">
    </PIN>
-   <BOUNDS type="Box" left="4020" top="4500">
+   <BOUNDS type="Box" left="4620" top="4500">
    </BOUNDS>
    </NODE>
    <NODE systemname="MouseEvents (Mouse Split)" filename="%VVVV%\lib\nodes\plugins\VVVV.Nodes.dll" nodename="MouseEvents (Mouse Split)" componentmode="Hidden" id="12">
-   <BOUNDS type="Node" left="4035" top="1380" width="100" height="100">
+   <BOUNDS type="Node" left="4635" top="1380" width="100" height="100">
    </BOUNDS>
    <PIN pinname="Mouse" visible="1" slicecount="1" values="||">
    </PIN>
@@ -79,7 +79,7 @@
    </PIN>
    <PIN pinname="PositionXY" visible="1">
    </PIN>
-   <BOUNDS type="Box" left="4035" top="1380">
+   <BOUNDS type="Box" left="4635" top="1380">
    </BOUNDS>
    </NODE>
    <LINK srcnodeid="2" srcpinname="Output Node" dstnodeid="12" dstpinname="Mouse">
@@ -105,11 +105,11 @@
    <NODE id="13" componentmode="Hidden" systemname="Multiply (2d Vector)" filename="%VVVV%\lib\nodes\modules\2D\Multiply (2d Vector).v4p" nodename="Multiply (2d Vector)" hiddenwhenlocked="0" managers="">
    <BOUNDS type="Window" left="17805" top="4410" width="4620" height="5505">
    </BOUNDS>
-   <BOUNDS type="Node" left="2085" top="2820" width="100" height="100">
+   <BOUNDS type="Node" left="2685" top="2820" width="100" height="100">
    </BOUNDS>
    <PIN pinname="XY" visible="1" pintype="Output">
    </PIN>
-   <BOUNDS type="Box" left="1320" top="945" width="4800" height="3600">
+   <BOUNDS type="Box" left="1920" top="945" width="4800" height="3600">
    </BOUNDS>
    <PIN pinname="Descriptive Name" pintype="Configuration" slicecount="1" values="||">
    </PIN>
@@ -125,25 +125,25 @@
    </PIN>
    </NODE>
    <LINK srcnodeid="13" srcpinname="XY" dstnodeid="11" dstpinname="PositionXY" linkstyle="Bezier">
-   <LINKPOINT x="2120" y="3688">
+   <LINKPOINT x="2720" y="3688">
    </LINKPOINT>
-   <LINKPOINT x="4210" y="3768">
+   <LINKPOINT x="4810" y="3768">
    </LINKPOINT>
    </LINK>
    <NODE nodename="IOBox (Node)" componentmode="InABox" id="14" systemname="IOBox (Node)">
-   <BOUNDS type="Box" left="2100" top="810" width="795" height="240">
+   <BOUNDS type="Box" left="2700" top="810" width="795" height="240">
    </BOUNDS>
-   <BOUNDS type="Node" left="2100" top="810" width="0" height="0">
+   <BOUNDS type="Node" left="2700" top="810" width="0" height="0">
    </BOUNDS>
    <PIN pinname="Input Node" slicecount="1" visible="1" values="||">
    </PIN>
    <PIN pinname="Descriptive Name" slicecount="1" values="Transform">
    </PIN>
+   <PIN pinname="Output Node" visible="1">
+   </PIN>
    </NODE>
-   <LINK srcnodeid="14" srcpinname="Output Node" dstnodeid="13" dstpinname="Transform">
-   </LINK>
    <NODE systemname="MouseEvents (Mouse Join)" filename="%VVVV%\lib\nodes\plugins\VVVV.Nodes.dll" nodename="MouseEvents (Mouse Join)" componentmode="Hidden" id="18">
-   <BOUNDS type="Node" left="1305" top="4560" width="100" height="100">
+   <BOUNDS type="Node" left="1905" top="4560" width="100" height="100">
    </BOUNDS>
    <PIN pinname="Event Type" slicecount="1" visible="1" values="MouseMove">
    </PIN>
@@ -153,13 +153,13 @@
    </PIN>
    <PIN pinname="Bin Size" slicecount="1" visible="1" values="0">
    </PIN>
-   <BOUNDS type="Box" left="1305" top="4560">
+   <BOUNDS type="Box" left="1905" top="4560">
    </BOUNDS>
    </NODE>
    <NODE nodename="IOBox (Enumerations)" componentmode="InABox" id="19" systemname="IOBox (Enumerations)">
-   <BOUNDS type="Box" left="465" top="4005" width="1125" height="255">
+   <BOUNDS type="Box" left="1065" top="4005" width="1125" height="255">
    </BOUNDS>
-   <BOUNDS type="Node" left="465" top="4005" width="0" height="0">
+   <BOUNDS type="Node" left="1065" top="4005" width="0" height="0">
    </BOUNDS>
    <PIN pinname="Input Enum" slicecount="1" visible="1" values="MouseMove">
    </PIN>
@@ -169,7 +169,7 @@
    <LINK srcnodeid="13" srcpinname="XY" dstnodeid="18" dstpinname="PositionXY">
    </LINK>
    <NODE systemname="Merge (Mouse)" filename="%VVVV%\lib\nodes\plugins\VVVV.Nodes.dll" nodename="Merge (Mouse)" componentmode="Hidden" id="21">
-   <BOUNDS type="Node" left="1305" top="5160" width="100" height="100">
+   <BOUNDS type="Node" left="1905" top="5160" width="100" height="100">
    </BOUNDS>
    <PIN pinname="Mouse 1" visible="1">
    </PIN>
@@ -181,13 +181,13 @@
    <LINK srcnodeid="18" srcpinname="Mouse" dstnodeid="21" dstpinname="Mouse 1">
    </LINK>
    <LINK srcnodeid="11" srcpinname="Mouse" dstnodeid="21" dstpinname="Mouse 2" linkstyle="VHV">
-   <LINKPOINT x="4050" y="5040">
+   <LINKPOINT x="4650" y="5040">
    </LINKPOINT>
-   <LINKPOINT x="1830" y="5040">
+   <LINKPOINT x="2430" y="5040">
    </LINKPOINT>
    </LINK>
    <NODE systemname="Change (Animation)" nodename="Change (Animation)" componentmode="Hidden" id="23">
-   <BOUNDS type="Node" left="2085" top="3660" width="100" height="100">
+   <BOUNDS type="Node" left="2685" top="3660" width="100" height="100">
    </BOUNDS>
    <PIN pinname="OnChange" visible="1">
    </PIN>
@@ -195,7 +195,7 @@
    </PIN>
    </NODE>
    <NODE systemname="OR (Boolean Spectral)" nodename="OR (Boolean Spectral)" componentmode="Hidden" id="24">
-   <BOUNDS type="Node" left="2100" top="4050" width="100" height="100">
+   <BOUNDS type="Node" left="2700" top="4050" width="100" height="100">
    </BOUNDS>
    <PIN pinname="Input" visible="1">
    </PIN>
@@ -211,9 +211,9 @@
    <LINK srcnodeid="21" srcpinname="Mouse" dstnodeid="10" dstpinname="Input Node">
    </LINK>
    <NODE nodename="IOBox (String)" componentmode="InABox" id="26" systemname="IOBox (String)">
-   <BOUNDS type="Node" left="6210" top="825" width="11280" height="270">
+   <BOUNDS type="Node" left="6810" top="825" width="11280" height="270">
    </BOUNDS>
-   <BOUNDS type="Box" left="6210" top="825" width="3810" height="540">
+   <BOUNDS type="Box" left="6810" top="825" width="3810" height="540">
    </BOUNDS>
    <PIN pinname="Input String" visible="0" slicecount="1" values="|Needs to create a new Mousemove event whenever the transform is changed, and merge this event. |">
    </PIN>
@@ -225,7 +225,7 @@
    </PIN>
    </NODE>
    <NODE systemname="S+H (Animation)" nodename="S+H (Animation)" componentmode="Hidden" id="27">
-   <BOUNDS type="Node" left="2835" top="2280" width="100" height="100">
+   <BOUNDS type="Node" left="3435" top="2280" width="100" height="100">
    </BOUNDS>
    <PIN pinname="Input" visible="1">
    </PIN>
@@ -235,7 +235,7 @@
    </PIN>
    </NODE>
    <NODE systemname="GT (Value)" nodename="GT (Value)" componentmode="Hidden" id="28">
-   <BOUNDS type="Node" left="5610" top="1800" width="100" height="100">
+   <BOUNDS type="Node" left="6210" top="1800" width="100" height="100">
    </BOUNDS>
    <PIN pinname="Input 1" visible="1">
    </PIN>
@@ -247,11 +247,55 @@
    <LINK srcnodeid="27" srcpinname="Output" dstnodeid="13" dstpinname="XY">
    </LINK>
    <LINK srcnodeid="12" srcpinname="PositionXY" dstnodeid="27" dstpinname="Input" linkstyle="Bezier">
-   <LINKPOINT x="4200" y="1950">
+   <LINKPOINT x="4800" y="1950">
    </LINKPOINT>
-   <LINKPOINT x="2895" y="1950">
+   <LINKPOINT x="3495" y="1950">
    </LINKPOINT>
    </LINK>
    <LINK srcnodeid="28" srcpinname="Output" dstnodeid="27" dstpinname="Set">
+   </LINK>
+   <NODE systemname="GetSlice (Node)" nodename="GetSlice (Node)" componentmode="Hidden" id="29">
+   <BOUNDS type="Node" left="2685" top="2280" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input Node" visible="1">
+   </PIN>
+   <PIN pinname="Output Node" visible="1">
+   </PIN>
+   <PIN pinname="Index" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="14" srcpinname="Output Node" dstnodeid="29" dstpinname="Input Node">
+   </LINK>
+   <LINK srcnodeid="29" srcpinname="Output Node" dstnodeid="13" dstpinname="Transform">
+   </LINK>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="30" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="255" top="285" width="9435" height="480">
+   </BOUNDS>
+   <BOUNDS type="Box" left="255" top="285" width="2250" height="2370">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="|Use only the first slice of Transforms that comes in; anything else does not really make sense (Most of the time, it would just use the first transform, anyway. Only when multiple MouseEvents come in, the second, third... transform would be used, which is very confusing.)&cr;&lf;&gt;|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="32" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="3315" top="1635" width="285" height="240">
+   </BOUNDS>
+   <BOUNDS type="Node" left="3315" top="1635" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" visible="1" values="0">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Integer">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="32" srcpinname="Y Output Value" dstnodeid="29" dstpinname="Index">
    </LINK>
    </PATCH>


### PR DESCRIPTION
Using getSlice to only get the first transform, in case there are
multiple slices coming in.

anything else does not really make sense (Most of the time, it would
just use the first transform, anyway. Only when multiple MouseEvents
come in, the second, third... transform would be used, which is very
confusing.)

Technically, multiple Mouse Slices should be given out when multiple transformation slices come in. Is there any real usecase for that, though?
