### PR TITLE
[Core] Make InputAttribute and OutputAttribute non sealed

### DIFF
--- a/vvvv45/src/core/PluginInterfaces/V2/InputAttribute.cs
+++ b/vvvv45/src/core/PluginInterfaces/V2/InputAttribute.cs
@@ -5,7 +5,7 @@ using System.ComponentModel.Composition;
 namespace VVVV.PluginInterfaces.V2
 {
     [ComVisible(false)]
-    public sealed class InputAttribute : IOAttribute
+    public class InputAttribute : IOAttribute
     {
         public static readonly int DefaultBinSize = -1;
         public static readonly string DefaultBinName = " Bin Size";

--- a/vvvv45/src/core/PluginInterfaces/V2/OutputAttribute.cs
+++ b/vvvv45/src/core/PluginInterfaces/V2/OutputAttribute.cs
@@ -5,7 +5,7 @@ using System.ComponentModel.Composition;
 namespace VVVV.PluginInterfaces.V2
 {
     [ComVisible(false)]
-    public sealed class OutputAttribute : IOAttribute
+    public class OutputAttribute : IOAttribute
     {
         public static readonly string DefaultBinName = " Bin Size";
         


### PR DESCRIPTION
As said in the title, so they can be eventually overriden
