### PR TITLE
making pins of more complex iotypes accessible

### DIFF
--- a/vvvv45/src/core/Hosting/Hosting.csproj
+++ b/vvvv45/src/core/Hosting/Hosting.csproj
@@ -78,6 +78,7 @@
     <Compile Include="IO\ComIStream.cs" />
     <Compile Include="IO\ComStream.cs" />
     <Compile Include="IO\DynamicTypeWrapper.cs" />
+    <Compile Include="IO\IIOMultiPin.cs" />
     <Compile Include="IO\PluginContainer.cs" />
     <Compile Include="IO\PointerRegistry.cs" />
     <Compile Include="IO\Pointers\ColorInput.cs" />

--- a/vvvv45/src/core/Hosting/IO/GenericIOContainer.cs
+++ b/vvvv45/src/core/Hosting/IO/GenericIOContainer.cs
@@ -19,7 +19,8 @@ namespace VVVV.Hosting.IO
         {
             // We need to construct with runtime type here, as compiletime type might be too simple (cast exceptions later).
             var ioHandlerType = typeof(GenericIOContainer<>).MakeGenericType(ioObject.GetType());
-            return (IIOContainer) Activator.CreateInstance(ioHandlerType, context, factory, ioObject, syncAction, flushAction);
+            var containers = ioObject as IIOMultiPin;
+            return (IIOContainer)Activator.CreateInstance(ioHandlerType, context, factory, containers.BaseContainer, ioObject, containers.AssociatedContainers, syncAction, flushAction);
         }
     }
     
@@ -33,11 +34,13 @@ namespace VVVV.Hosting.IO
         public GenericIOContainer(
             IOBuildContext context,
             IIOFactory factory,
+            IIOContainer baseIOContainer,
             T ioObject,
+            IIOContainer[] associatedContainers,
             Action<T> syncAction = null,
             Action<T> flushAction = null
            )
-            : base(context, factory, ioObject)
+            : base(context, factory, baseIOContainer, ioObject, associatedContainers)
         {
             IOObject = ioObject;
             SyncAction = syncAction;

--- a/vvvv45/src/core/Hosting/IO/IIOMultiPin.cs
+++ b/vvvv45/src/core/Hosting/IO/IIOMultiPin.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using VVVV.PluginInterfaces.V2;
+
+namespace VVVV.Hosting.IO
+{
+    [ComVisible(false)]
+    public interface IIOMultiPin
+    {
+        IIOContainer BaseContainer { get; }
+        IIOContainer[] AssociatedContainers { get; }
+    }
+}

--- a/vvvv45/src/core/Hosting/IO/IOContainerBase.cs
+++ b/vvvv45/src/core/Hosting/IO/IOContainerBase.cs
@@ -116,11 +116,12 @@ namespace VVVV.Hosting.IO
     [ComVisible(false)]
     public abstract class IOContainerBase : IIOContainer
     {
-        public IOContainerBase(IOBuildContext context, IIOFactory factory, IIOContainer baseContainer, object rawIOObject)
+        public IOContainerBase(IOBuildContext context, IIOFactory factory, IIOContainer baseContainer, object rawIOObject, IIOContainer[] associatedContainers)
         {
             Factory = factory;
             BaseContainer = baseContainer;
             RawIOObject = rawIOObject;
+            AssociatedContainers = associatedContainers;
             if (context.SubscribeToIOEvents)
             {
                 Factory.Disposing += HandleFactoryDisposing;
@@ -128,13 +129,13 @@ namespace VVVV.Hosting.IO
         }
 
         public IOContainerBase(IOBuildContext context, IIOContainer baseContainer, object rawIOObject)
-            : this(context, baseContainer.Factory, baseContainer, rawIOObject)
+            : this(context, baseContainer.Factory, baseContainer, rawIOObject, null)
         {
             
         }
         
         public IOContainerBase(IOBuildContext context, IIOFactory factory, object rawIOObject)
-            : this(context, factory, null, rawIOObject)
+            : this(context, factory, null, rawIOObject, null)
         {
             
         }
@@ -156,11 +157,22 @@ namespace VVVV.Hosting.IO
             get;
             private set;
         }
+
+        public IIOContainer[] AssociatedContainers
+        {
+            get;
+            private set;
+        }
         
         public virtual void Dispose()
         {
             Factory.Disposing -= HandleFactoryDisposing;
-            if (BaseContainer != null)
+            /*
+            AdditionalContainers are null except for GenericIOContainers
+            on multi pin types, which handle all their pin disposing internally already
+            so only call BaseContainer.Dispose on single pin types
+            */
+            if (BaseContainer != null && AssociatedContainers == null)
             {
                 BaseContainer.Dispose();
             }

--- a/vvvv45/src/core/Hosting/IO/IOFactory.cs
+++ b/vvvv45/src/core/Hosting/IO/IOFactory.cs
@@ -215,6 +215,14 @@ namespace VVVV.Hosting.IO
                 set;
             }
 
+            public IIOContainer[] AssociatedContainers
+            {
+                get
+                {
+                    throw new NotImplementedException();
+                }
+            }
+
             public void Dispose()
             {
                 // Do nothing

--- a/vvvv45/src/core/Hosting/IO/Pins/BinSpread.cs
+++ b/vvvv45/src/core/Hosting/IO/Pins/BinSpread.cs
@@ -9,7 +9,7 @@ namespace VVVV.Hosting.Pins
 	/// Base class of 2d spreads.
 	/// </summary>
 	[ComVisible(false)]
-	public abstract class BinSpread<T> : Spread<ISpread<T>>
+	public abstract class BinSpread<T> : Spread<ISpread<T>>, VVVV.Hosting.IO.IIOMultiPin
 	{
 		public class BinSpreadStream : MemoryIOStream<ISpread<T>>
 		{
@@ -38,8 +38,12 @@ namespace VVVV.Hosting.Pins
 		}
 		
 		protected readonly IIOFactory FIOFactory;
-		
-		public BinSpread(IIOFactory ioFactory, IOAttribute attribute, BinSpreadStream stream)
+
+        public abstract IIOContainer BaseContainer { get; }
+
+        public abstract IIOContainer[] AssociatedContainers { get; }
+
+        public BinSpread(IIOFactory ioFactory, IOAttribute attribute, BinSpreadStream stream)
 			: base(stream)
 		{
 			FIOFactory = ioFactory;

--- a/vvvv45/src/core/Hosting/IO/Pins/Input/InputBinSpread.cs
+++ b/vvvv45/src/core/Hosting/IO/Pins/Input/InputBinSpread.cs
@@ -11,13 +11,13 @@ namespace VVVV.Hosting.Pins.Input
     {
         public class InputBinSpreadStream : BinSpreadStream, IDisposable
         {
-            private readonly IIOContainer<IInStream<T>> FDataContainer;
-            private readonly IIOContainer<IInStream<int>> FBinSizeContainer;
+            internal readonly IIOContainer<IInStream<T>> FDataContainer;
+            internal readonly IIOContainer<IInStream<int>> FBinSizeContainer;
             private readonly IInStream<T> FDataStream;
             private readonly IInStream<int> FBinSizeStream;
             private readonly IPluginIO FDataIO;
             private bool FOwnsBinSizeContainer;
-            
+
             public InputBinSpreadStream(IIOFactory ioFactory, InputAttribute attribute)
                 : this(ioFactory, attribute, false)
             {
@@ -107,7 +107,23 @@ namespace VVVV.Hosting.Pins.Input
         }
         
         private readonly InputBinSpreadStream FStream;
-        
+
+        public override IIOContainer BaseContainer
+        {
+            get
+            {
+                return FStream.FDataContainer;
+            }
+        }
+
+        public override IIOContainer[] AssociatedContainers
+        {
+            get
+            {
+                return new IIOContainer[]{ FStream.FBinSizeContainer };
+            }
+        }
+
         public InputBinSpread(IIOFactory ioFactory, InputAttribute attribute)
             : this(ioFactory, attribute, new InputBinSpreadStream(ioFactory, attribute))
         {

--- a/vvvv45/src/core/Hosting/IO/Pins/Output/OutputBinSpread.cs
+++ b/vvvv45/src/core/Hosting/IO/Pins/Output/OutputBinSpread.cs
@@ -2,6 +2,7 @@
 using System.Runtime.InteropServices;
 using VVVV.PluginInterfaces.V2;
 using VVVV.Utils.Streams;
+using VVVV.PluginInterfaces.V1;
 
 namespace VVVV.Hosting.Pins.Output
 {
@@ -10,12 +11,12 @@ namespace VVVV.Hosting.Pins.Output
     {
         public class OutputBinSpreadStream : BinSpreadStream, IDisposable
         {
-            private readonly IIOContainer<IOutStream<T>> FDataContainer;
-            private readonly IIOContainer<IOutStream<int>> FBinSizeContainer;
+            internal readonly IIOContainer<IOutStream<T>> FDataContainer;
+            internal readonly IIOContainer<IOutStream<int>> FBinSizeContainer;
             private readonly IOutStream<T> FDataStream;
             private readonly IOutStream<int> FBinSizeStream;
             private bool FOwnsBinSizeContainer;
-            
+
             public OutputBinSpreadStream(IIOFactory ioFactory, OutputAttribute attribute)
                 : this(ioFactory, attribute, () => ioFactory.CreateIOContainer<IOutStream<int>>(attribute.GetBinSizeOutputAttribute(), false))
             {
@@ -111,7 +112,23 @@ namespace VVVV.Hosting.Pins.Output
         }
         
         private readonly OutputBinSpreadStream FStream;
-        
+
+        public override IIOContainer BaseContainer
+        {
+            get
+            {
+                return FStream.FDataContainer;
+            }
+        }
+
+        public override IIOContainer[] AssociatedContainers
+        {
+            get
+            {
+                return new IIOContainer[] { FStream.FBinSizeContainer };
+            }
+        }
+
         public OutputBinSpread(IIOFactory ioFactory, OutputAttribute attribute)
             : this(ioFactory, attribute, new OutputBinSpreadStream(ioFactory, attribute))
         {

--- a/vvvv45/src/core/Hosting/IO/Pins/SpreadList.cs
+++ b/vvvv45/src/core/Hosting/IO/Pins/SpreadList.cs
@@ -10,7 +10,7 @@ namespace VVVV.Hosting.Pins
 	/// base class for spread lists
 	/// </summary>
 	[ComVisible(false)]
-	abstract class SpreadList<TSpread> : Spread<TSpread>, IDisposable
+	abstract class SpreadList<TSpread> : Spread<TSpread>, VVVV.Hosting.IO.IIOMultiPin, IDisposable 
 	    where TSpread : class, ISynchronizable, IFlushable
 	{
 	    class SpreadListStream : MemoryIOStream<TSpread>
@@ -42,8 +42,24 @@ namespace VVVV.Hosting.Pins
 		protected int FOffsetCounter;
 		protected static int FInstanceCounter = 1;
         private bool FForceOnNextFlush;
-		
-		public SpreadList(IIOFactory factory, IOAttribute attribute)
+
+        public IIOContainer BaseContainer
+        {
+            get
+            {
+                return FCountSpread as IIOContainer;
+            }
+        }
+
+        public IIOContainer[] AssociatedContainers
+        {
+            get
+            {
+                return FIOContainers.ToArray();
+            }
+        }
+
+        public SpreadList(IIOFactory factory, IOAttribute attribute)
 		    : base(new SpreadListStream())
 		{
 			//store fields

--- a/vvvv45/src/core/Hosting/IO/Streams/GroupInStream.cs
+++ b/vvvv45/src/core/Hosting/IO/Streams/GroupInStream.cs
@@ -5,7 +5,7 @@ using VVVV.Utils.Streams;
 
 namespace VVVV.Hosting.IO.Streams
 {
-	class GroupInStream<T> : IInStream<IInStream<T>>//, IDisposable
+	class GroupInStream<T> : IInStream<IInStream<T>>, IIOMultiPin//, IDisposable
 	{
 		private readonly MemoryIOStream<IInStream<T>> FStreams = new MemoryIOStream<IInStream<T>>(2);
 		private readonly List<IIOContainer> FIOContainers = new List<IIOContainer>();
@@ -95,8 +95,24 @@ namespace VVVV.Hosting.IO.Streams
 		}
 		
 		public bool IsChanged { get; private set; }
-		
-		public object Clone()
+
+        public IIOContainer BaseContainer
+        {
+            get
+            {
+                return FCountSpread as IIOContainer;
+            }
+        }
+
+        public IIOContainer[] AssociatedContainers
+        {
+            get
+            {
+                return FIOContainers.ToArray();
+            }
+        }
+
+        public object Clone()
 		{
 			throw new NotImplementedException();
 		}

--- a/vvvv45/src/core/Hosting/IO/Streams/GroupOutStream.cs
+++ b/vvvv45/src/core/Hosting/IO/Streams/GroupOutStream.cs
@@ -5,7 +5,7 @@ using VVVV.Utils.Streams;
 
 namespace VVVV.Hosting.IO.Streams
 {
-    class GroupOutStream<T> : IInStream<IOutStream<T>>, IFlushable, IDisposable
+    class GroupOutStream<T> : IInStream<IOutStream<T>>, IIOMultiPin, IFlushable, IDisposable
     {
         private readonly MemoryIOStream<IOutStream<T>> FStreams = new MemoryIOStream<IOutStream<T>>(2);
         private readonly List<IIOContainer> FIOContainers = new List<IIOContainer>();
@@ -94,6 +94,22 @@ namespace VVVV.Hosting.IO.Streams
             get
             {
                 return FStreams.IsChanged;
+            }
+        }
+
+        public IIOContainer BaseContainer
+        {
+            get
+            {
+                return FCountSpread as IIOContainer;
+            }
+        }
+
+        public IIOContainer[] AssociatedContainers
+        {
+            get
+            {
+                return FIOContainers.ToArray();
             }
         }
 

--- a/vvvv45/src/core/Hosting/IO/Streams/MultiDimInStream.cs
+++ b/vvvv45/src/core/Hosting/IO/Streams/MultiDimInStream.cs
@@ -3,11 +3,10 @@ using System.Diagnostics;
 using VVVV.PluginInterfaces.V2;
 using VVVV.Utils;
 using VVVV.Utils.Streams;
-using System.Collections.Generic;
 
 namespace VVVV.Hosting.IO.Streams
 {
-    class MultiDimInStream<T> : MemoryIOStream<IInStream<T>>, IDisposable
+    class MultiDimInStream<T> : MemoryIOStream<IInStream<T>>, IIOMultiPin, IDisposable
     {
         class InnerStream : IInStream<T>
         {
@@ -165,7 +164,23 @@ namespace VVVV.Hosting.IO.Streams
         private readonly IIOContainer<IInStream<int>> FBinSizeContainer;
         private readonly IInStream<T> FDataStream;
         private readonly IntInStream FBinSizeStream;
-        
+
+        public IIOContainer BaseContainer
+        {
+            get
+            {
+                return FDataContainer;
+            }
+        }
+
+        public IIOContainer[] AssociatedContainers
+        {
+            get
+            {
+                return new IIOContainer[]{ FBinSizeContainer };
+            }
+        }
+
         public MultiDimInStream(IIOFactory factory, InputAttribute attribute)
         {
             FDataContainer = factory.CreateIOContainer<IInStream<T>>(attribute, false);

--- a/vvvv45/src/core/Hosting/IO/Streams/MultiDimOutStream.cs
+++ b/vvvv45/src/core/Hosting/IO/Streams/MultiDimOutStream.cs
@@ -4,13 +4,29 @@ using VVVV.Utils.Streams;
 
 namespace VVVV.Hosting.IO.Streams
 {
-    class MultiDimOutStream<T> : MemoryIOStream<IInStream<T>>, IDisposable
+    class MultiDimOutStream<T> : MemoryIOStream<IInStream<T>>, IIOMultiPin, IDisposable
     {
         private readonly IIOContainer<IOutStream<T>> FDataContainer;
         private readonly IIOContainer<IOutStream<int>> FBinSizeContainer;
         private readonly IOutStream<T> FDataStream;
         private readonly IOutStream<int> FBinSizeStream;
-        
+
+        public IIOContainer BaseContainer
+        {
+            get
+            {
+                return FDataContainer;
+            }
+        }
+
+        public IIOContainer[] AssociatedContainers
+        {
+            get
+            {
+                return new IIOContainer[]{ FBinSizeContainer };
+            }
+        }
+
         public MultiDimOutStream(IIOFactory ioFactory, OutputAttribute attribute)
         {
             FDataContainer = ioFactory.CreateIOContainer<IOutStream<T>>(attribute, false);

--- a/vvvv45/src/core/PluginInterfaces/V2/IO/IIOContainer.cs
+++ b/vvvv45/src/core/PluginInterfaces/V2/IO/IIOContainer.cs
@@ -31,6 +31,8 @@ namespace VVVV.PluginInterfaces.V2
         /// Gets the io factory which was used to create this container.
         /// </summary>
         IIOFactory Factory { get; }
+
+        IIOContainer[] AssociatedContainers { get; }
     }
     
     [ComVisible(false)]


### PR DESCRIPTION
probably @azeno:
didn't extend the BaseContainer property from IIOContainer to array to not break any external code. interface and implementation is as little intrusive as possible, doesn't affect single pin types at all.

disposing of all those classes work properly. i'm assuming thou, that any class using GenericIOContainer handles pin disposing internally already, which is true for any types in the sdk... don't know if anyone else is using that though...
