### PR TITLE
Got rid of clamping in Mouse (Desktop) node in raw mode (round 2)

### DIFF
--- a/vvvv45/src/nodes/plugins/System/MouseNodes.cs
+++ b/vvvv45/src/nodes/plugins/System/MouseNodes.cs
@@ -408,7 +408,7 @@ namespace VVVV.Nodes.Input
                     position = new Point(args.X / virtualScreenSize.Width, args.Y / virtualScreenSize.Height);
                     break;
                 case MouseMode.MoveRelative:
-                    position = new Point(VMath.Clamp(args.X + position.X, 0, virtualScreenSize.Width - 1), VMath.Clamp(args.Y + position.Y, 0, virtualScreenSize.Height - 1));
+                    position = new Point(args.X + position.X, args.Y + position.Y);
                     break;
                 case MouseMode.VirtualDesktop:
                     position = new Point(args.X, args.Y);

--- a/vvvv45/src/nodes/plugins/System/MouseNodes.cs
+++ b/vvvv45/src/nodes/plugins/System/MouseNodes.cs
@@ -408,7 +408,14 @@ namespace VVVV.Nodes.Input
                     position = new Point(args.X / virtualScreenSize.Width, args.Y / virtualScreenSize.Height);
                     break;
                 case MouseMode.MoveRelative:
-                    position = new Point(args.X + position.X, args.Y + position.Y);
+
+                    // this will keep mouse relative coordinates proportional
+                    // so a distance traveled on X axis == same distance traveled on Y axis
+                    var minAsp = Math.Min(virtualScreenSize.Width, virtualScreenSize.Height);
+                    var screenAspW = virtualScreenSize.Width / minAsp;
+                    var screenAspH = virtualScreenSize.Height / minAsp;
+
+                    position = new Point(args.X * screenAspW + position.X, args.Y * screenAspH + position.Y);
                     break;
                 case MouseMode.VirtualDesktop:
                     position = new Point(args.X, args.Y);


### PR DESCRIPTION
in previous pull request I wrote:

"You can read about reasons here: https://vvvv.org/forum/why-normalized-space-with-desktop-stuff
Do clamping in vvvv via Mouse -> FrameDifference -> Counter / FrameDelay-Add-Map, this is the only reason I didn't get rid of my DirectInput node yet and I really want to get rid of it because it messes up desktop keyboard and mouse nodes."

In this one I also added proportional relative coordinates. see comment why is that good.
