### PR TITLE
Imageplayer keeps player instance on slice position change

### DIFF
--- a/vvvv45/src/nodes/plugins/Texture/ImagePlayer/PlayerNode.cs
+++ b/vvvv45/src/nodes/plugins/Texture/ImagePlayer/PlayerNode.cs
@@ -114,8 +114,22 @@ namespace VVVV.Nodes.ImagePlayer
                 .CombineWith(FPreloadFramesIn)
                 .CombineWith(FReloadIn);
             
-            FImagePlayers.Resize(spreadMax, CreateImagePlayer, DestroyImagePlayer);
-            
+            var oldPlayers = new List<ImagePlayer>(FImagePlayers.ToList());
+
+            FImagePlayers.SliceCount = spreadMax;
+            for (int i = 0; i < spreadMax; i++)
+            {
+                var player = oldPlayers.Where(p => p.Directories.SpreadEqual(FDirectoryIn[i])).DefaultIfEmpty(null).First();
+                if (player == null)
+                    player = CreateImagePlayer(i);
+                else
+                    oldPlayers.Remove(player);
+
+                FImagePlayers[i] = player;
+            }
+            foreach (var p in oldPlayers)
+                DestroyImagePlayer(p);
+
             FImagePlayers.SliceCount = spreadMax;
             FTextureOut.SliceCount = spreadMax;
             FTextureWidthOut.SliceCount = spreadMax;

--- a/vvvv45/src/nodes/plugins/Texture/ImagePlayer/PlayerNode.cs
+++ b/vvvv45/src/nodes/plugins/Texture/ImagePlayer/PlayerNode.cs
@@ -113,13 +113,13 @@ namespace VVVV.Nodes.ImagePlayer
                 .CombineWith(FVisibleFramesIn)
                 .CombineWith(FPreloadFramesIn)
                 .CombineWith(FReloadIn);
-            
-            var oldPlayers = new List<ImagePlayer>(FImagePlayers.ToList());
+
+            List<ImagePlayer> oldPlayers = FImagePlayers.ToList();
 
             FImagePlayers.SliceCount = spreadMax;
             for (int i = 0; i < spreadMax; i++)
             {
-                var player = oldPlayers.Where(p => p.Directories.SpreadEqual(FDirectoryIn[i])).DefaultIfEmpty(null).First();
+                var player = oldPlayers.FirstOrDefault(p => p.Directories.SpreadEqual(FDirectoryIn[i]));
                 if (player == null)
                     player = CreateImagePlayer(i);
                 else


### PR DESCRIPTION
was previously discarding preloaded data if dir input changed to another slice